### PR TITLE
feat(layout): reorganize content layout to right-aligned clear zones avoiding 3D island occlusion

### DIFF
--- a/src/components/sections/About/About.module.css
+++ b/src/components/sections/About/About.module.css
@@ -16,25 +16,27 @@
 .content {
   position: relative;
   z-index: 2;
-  max-width: 1400px;
-  margin: 0;
   width: 100%;
-  padding: 0 max(2rem, 5vw);
+  max-width: 100vw;
+  margin: 0;
+  padding: 0 5vw;
   pointer-events: auto;
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 2.5rem;
+  box-sizing: border-box;
 }
 
 .header {
   text-align: left;
-  margin-bottom: 2rem;
+  margin-bottom: 1.5rem;
+  max-width: 650px;
 }
 
 .title {
-  font-size: clamp(2.5rem, 6vw, 6rem);
+  font-size: clamp(2.5rem, 5vw, 5rem);
   font-weight: 600;
-  line-height: 0.9;
+  line-height: 0.95;
   letter-spacing: -0.03em;
   color: var(--strong-text);
   margin: 0;
@@ -43,93 +45,78 @@
 }
 
 .subtitle {
-  font-size: clamp(1rem, 1.2vw, 1.2rem);
+  font-size: clamp(1rem, 1.1vw, 1.15rem);
   line-height: 1.4;
   color: rgb(var(--text-color));
   opacity: 0.9;
   margin: 1rem 0 0;
-  max-width: 600px;
+  max-width: 580px;
   text-shadow: 0 0 10px rgba(255, 255, 255, 0.1);
 }
 
 .aboutGrid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(min(350px, 100%), 1fr));
+  width: 100%;
+  max-width: 650px;
+  display: flex;
+  flex-direction: column;
   gap: 2rem;
   margin-bottom: 0;
 }
 
-.educationSection {
+/* Far Right-Aligned Section for Education & Certifications */
+.rightAlignedSection {
   width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  margin-top: 3rem;
+  box-sizing: border-box;
+}
+
+.rightAlignedInner {
+  width: 100%;
+  max-width: 520px;
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}
+
+@media (max-width: 1023px) {
+  .rightAlignedInner {
+    max-width: 100%;
+  }
 }
 
 .educationTitle,
 .sectionTitle {
-  font-size: clamp(1.75rem, 3vw, 3rem);
+  font-size: clamp(1.75rem, 2.5vw, 2.5rem);
   font-weight: 600;
   color: var(--strong-text);
-  margin: 0 0 2rem;
+  margin: 0 0 1.25rem;
   letter-spacing: -0.02em;
+  text-align: left;
   mix-blend-mode: difference;
 }
 
 .educationGrid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(min(350px, 100%), 1fr));
-  gap: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  width: 100%;
 }
 
 .cardContent {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.25rem;
   color: rgb(var(--text-color));
 }
 
 .educationMeta {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4rem;
   color: rgb(var(--text-color));
-}
-
-.wide {
-  grid-column: 1 / -1;
-}
-
-@media (min-width: 1367px) {
-  .content {
-    margin-top: -18vh;
-    padding-left: 10vw;
-  }
-
-  .educationGrid {
-    grid-template-columns: repeat(5, 1fr);
-  }
-
-  .wide {
-    grid-column: span 3;
-  }
-
-  .educationGrid > div:not(.wide) {
-    grid-column: span 2;
-  }
-
-  .cardContent {
-    gap: 2rem;
-    font-size: 1.25rem; /* Increased slightly for 1440p */
-  }
-
-  .educationMeta {
-    font-size: 1.3rem; /* Increased slightly for 1440p */
-  }
-}
-
-/* Fix for 1080p screens where overlap occurs */
-@media (min-width: 1024px) and (max-width: 1920px) {
-  .content {
-    margin-top: -12vh; /* Move down slightly to avoid arrow overlap */
-  }
 }
 
 :global([data-theme="light"]) .about {
@@ -157,86 +144,8 @@
   text-shadow: none;
 }
 
-/* 720p / Small Laptop Adjustments (Very Small) */
-@media (min-width: 769px) and (max-width: 1366px) {
-  .about {
-    padding-top: 32vh !important; /* Move section down significantly to clear arrow - Force override */
-  }
-
-  .title {
-    font-size: 2.5rem; /* Restored to large header size */
-  }
-
-  .sectionTitle,
-  .educationTitle {
-    font-size: 2rem; /* Restored to large header size */
-    margin-bottom: 0.5rem;
-  }
-
-  .content {
-    gap: 0.6rem;
-    margin-top: 0 !important; /* Force override any negative margins */
-    padding: 0 15vw; /* Decrease width by increasing padding */
-  }
-
-  .cardContent {
-    gap: 0.5rem;
-    font-size: 0.75rem !important; /* Proportional body text */
-    line-height: 1.4;
-  }
-
-  /* Target paragraphs inside cardContent (overriding Card.module.css) */
-  .cardContent p,
-  .description {
-    font-size: 0.85rem !important; /* Larger than tags */
-    line-height: 1.5;
-  }
-
-  .subtitle {
-    font-size: 0.9rem !important; /* Slightly larger for hierarchy */
-    margin-top: 0.5rem;
-    font-weight: 500;
-  }
-
-  .educationMeta {
-    font-size: 0.7rem !important; /* Proportional meta text */
-    gap: 0.2rem;
-  }
-
-  .header {
-    margin-bottom: 1rem;
-  }
-
-  .statValue {
-    font-size: 1.5rem;
-  }
-
-  .statLabel {
-    font-size: 0.7rem !important;
-  }
-
-  .tag {
-    font-size: 0.7rem !important;
-    padding: 0.25rem 0.5rem;
-  }
-}
-
-/* 1080p / Standard Desktop Adjustments (Small) */
-@media (min-width: 1367px) and (max-width: 1920px) {
-  .title {
-    font-size: 3.5rem;
-  }
-  .sectionTitle,
-  .educationTitle {
-    font-size: 2rem;
-  }
-  .content {
-    margin-top: -12vh;
-  }
-}
-
 .highlights {
-  justify-content: center;
+  justify-content: flex-start;
 }
 
 :global([data-theme="light"]) .about .description {

--- a/src/components/sections/About/About.test.tsx
+++ b/src/components/sections/About/About.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { About } from './About';
+
+// Mock framer-motion useScroll & useSpring
+vi.mock('framer-motion', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('framer-motion')>();
+  return {
+    ...actual,
+    useScroll: () => ({
+      scrollYProgress: { get: () => 0.5 },
+    }),
+    useSpring: (val: unknown) => val,
+    useTransform: () => 0,
+  };
+});
+
+describe('About Section', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders about me header, bio content and tags', () => {
+    render(<About />);
+    expect(screen.getByText('About Me')).toBeDefined();
+    expect(screen.getByText(/Software Engineer & Creative Developer/i)).toBeDefined();
+  });
+
+  it('renders education cards in the right-aligned layout', () => {
+    render(<About />);
+    expect(screen.getByText('Education')).toBeDefined();
+    expect(screen.getByText(/HiLCoE School of Computer Science/i)).toBeDefined();
+    expect(screen.getByText(/Saint Joseph School/i)).toBeDefined();
+  });
+
+  it('renders certifications cards cleanly', () => {
+    render(<About />);
+    expect(screen.getByText('Certifications')).toBeDefined();
+    expect(screen.getByText(/Bootdev/i)).toBeDefined();
+  });
+});

--- a/src/components/sections/About/About.tsx
+++ b/src/components/sections/About/About.tsx
@@ -74,72 +74,81 @@ export function About() {
           </motion.div>
         </div>
 
-        <div className={styles.sectionTitle}>Education</div>
-        <div className={styles.educationGrid}>
-          {cvData.education.map((edu, index) => (
-            <motion.div
-              key={edu.school}
-              className={edu.school.includes('HiLCoE') ? styles.wide : ''}
-              initial={{ opacity: 0, y: 30 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-              transition={{ 
-                duration: 0.8, 
-                ease: [0.76, 0, 0.24, 1],
-                delay: index * 0.1
-              }}
-            >
-              <Card>
-                <div className={styles.cardContent}>
-                  <CardTitle>{edu.school}</CardTitle>
-                  <div className={styles.educationMeta}>
-                    <CardText>{edu.degree}</CardText>
-                    <CardText>{edu.period}</CardText>
-                  </div>
-                  <TagsGrid>
-                    {edu.details.map((detail, i) => (
-                      <Tag key={i}>{detail}</Tag>
-                    ))}
-                  </TagsGrid>
-                </div>
-              </Card>
-            </motion.div>
-          ))}
-        </div>
+        {/* Education & Certifications: Right-Aligned Section (Clear 3D view on Left) */}
+        <div className={styles.rightAlignedSection}>
+          <div className={styles.rightAlignedInner}>
+            <div>
+              <div className={styles.sectionTitle}>Education</div>
+              <div className={styles.educationGrid}>
+                {cvData.education.map((edu, index) => (
+                  <motion.div
+                    key={edu.school}
+                    className={edu.school.includes('HiLCoE') ? styles.wide : ''}
+                    initial={{ opacity: 0, y: 30 }}
+                    whileInView={{ opacity: 1, y: 0 }}
+                    viewport={{ once: true }}
+                    transition={{ 
+                      duration: 0.8, 
+                      ease: [0.76, 0, 0.24, 1],
+                      delay: index * 0.1
+                    }}
+                  >
+                    <Card>
+                      <div className={styles.cardContent}>
+                        <CardTitle>{edu.school}</CardTitle>
+                        <div className={styles.educationMeta}>
+                          <CardText>{edu.degree}</CardText>
+                          <CardText>{edu.period}</CardText>
+                        </div>
+                        <TagsGrid>
+                          {edu.details.map((detail, i) => (
+                            <Tag key={i}>{detail}</Tag>
+                          ))}
+                        </TagsGrid>
+                      </div>
+                    </Card>
+                  </motion.div>
+                ))}
+              </div>
+            </div>
 
-        <div className={styles.sectionTitle} style={{ marginTop: '3rem' }}>Certifications</div>
-        <div className={styles.educationGrid}>
-          {cvData.certifications.map((cert, index) => (
-            <motion.div
-              key={cert.issuer}
-              className={cert.issuer.includes('Bootdev') ? styles.wide : ''}
-              initial={{ opacity: 0, y: 30 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-              transition={{ 
-                duration: 0.8, 
-                ease: [0.76, 0, 0.24, 1],
-                delay: index * 0.1
-              }}
-            >
-              <Card>
-                <div className={styles.cardContent}>
-                  <CardTitle>{cert.issuer}</CardTitle>
-                  <div className={styles.educationMeta}>
-                    <CardText>{cert.year}</CardText>
-                  </div>
-                  <CardText>{cert.description}</CardText>
-                  <TagsGrid>
-                    {cert.items.map((item, i) => (
-                      <Tag key={i}>{item}</Tag>
-                    ))}
-                  </TagsGrid>
-                </div>
-              </Card>
-            </motion.div>
-          ))}
+            <div style={{ marginTop: '2rem' }}>
+              <div className={styles.sectionTitle}>Certifications</div>
+              <div className={styles.educationGrid}>
+                {cvData.certifications.map((cert, index) => (
+                  <motion.div
+                    key={cert.issuer}
+                    className={cert.issuer.includes('Bootdev') ? styles.wide : ''}
+                    initial={{ opacity: 0, y: 30 }}
+                    whileInView={{ opacity: 1, y: 0 }}
+                    viewport={{ once: true }}
+                    transition={{ 
+                      duration: 0.8, 
+                      ease: [0.76, 0, 0.24, 1],
+                      delay: index * 0.1
+                    }}
+                  >
+                    <Card>
+                      <div className={styles.cardContent}>
+                        <CardTitle>{cert.issuer}</CardTitle>
+                        <div className={styles.educationMeta}>
+                          <CardText>{cert.year}</CardText>
+                        </div>
+                        <CardText>{cert.description}</CardText>
+                        <TagsGrid>
+                          {cert.items.map((item, i) => (
+                            <Tag key={i}>{item}</Tag>
+                          ))}
+                        </TagsGrid>
+                      </div>
+                    </Card>
+                  </motion.div>
+                ))}
+              </div>
+            </div>
+          </div>
         </div>
       </motion.div>
     </section>
   );
-} 
+}


### PR DESCRIPTION
## Summary

Reorganizes page content layout into right-aligned clear zones to avoid visual occlusion with the central 3D island model.

## Changes

- Shifted overlay text and card layouts to right-aligned viewport zones
- Preserved unobstructed sightlines for background 3D canvas elements

## Verification

- [x] Tests pass locally
- [x] Production build succeeds
