### PR TITLE
feat(3d): add interactive cursor camera parallax tilt & inertial damping physics (closes #24)

### DIFF
--- a/src/components/BackgroundScene.test.tsx
+++ b/src/components/BackgroundScene.test.tsx
@@ -47,11 +47,12 @@ vi.mock('@react-three/fiber', () => ({
     },
     size: { width: 1920, height: 1080 },
   }),
-  useFrame: (callback: (state: any) => void) => {
+  useFrame: (callback: (state: any, delta?: number) => void) => {
     callback({
       clock: { getElapsedTime: () => 1.5 },
       mouse: { x: 0.5, y: -0.2 },
-    });
+      camera: { position: { x: 0, y: 5, z: 30 } },
+    }, 0.016);
   },
 }));
 

--- a/src/components/BackgroundScene.tsx
+++ b/src/components/BackgroundScene.tsx
@@ -177,20 +177,34 @@ export function BackgroundScene({ theme, particleCount = 1000 }: BackgroundScene
         };
   }, [isLight]);
 
-  useFrame((state) => {
+  const smoothedMouse = useRef({ x: 0, y: 0 });
+
+  useFrame((state, delta) => {
     if (!sceneRef.current || !prismRef.current) return;
 
     const time = state.clock.getElapsedTime();
     const scrollProgress = scroll?.offset ?? 0;
     const reducedMotion = getPrefersReducedMotion();
 
-    // Scene parallax based on mouse (dampened if reduced motion)
-    const mouseX = reducedMotion ? 0 : state.mouse.x * 0.25;
-    const mouseY = reducedMotion ? 0 : state.mouse.y * 0.15;
-    sceneRef.current.rotation.y = mouseX * 0.15 + scrollProgress * Math.PI;
-    sceneRef.current.rotation.x = mouseY * 0.08;
+    // Inertial damping lerp on normalized cursor coordinates
+    const targetX = reducedMotion ? 0 : state.mouse.x;
+    const targetY = reducedMotion ? 0 : state.mouse.y;
+    const lerpFactor = Math.min(1, delta * 4);
 
-    // Prism animation (steady if reduced motion)
+    smoothedMouse.current.x = THREE.MathUtils.lerp(smoothedMouse.current.x, targetX, lerpFactor);
+    smoothedMouse.current.y = THREE.MathUtils.lerp(smoothedMouse.current.y, targetY, lerpFactor);
+
+    // Scene rotation parallax
+    sceneRef.current.rotation.y = smoothedMouse.current.x * 0.12 + scrollProgress * Math.PI;
+    sceneRef.current.rotation.x = smoothedMouse.current.y * 0.06;
+
+    // Subtle 3D camera spatial parallax offset
+    if (!reducedMotion && state.camera) {
+      state.camera.position.x = THREE.MathUtils.lerp(state.camera.position.x, smoothedMouse.current.x * 1.8, Math.min(1, delta * 2.5));
+      state.camera.position.y = THREE.MathUtils.lerp(state.camera.position.y, 5 + smoothedMouse.current.y * 1.2, Math.min(1, delta * 2.5));
+    }
+
+    // Neon prism floating animation
     prismRef.current.position.y = reducedMotion ? 2 : Math.sin(time * 0.5) * 0.2 + 2;
   });
 


### PR DESCRIPTION
## Summary

Adds interactive mouse cursor parallax tilt with inertial damping physics to the 3D camera controller.

## Changes

- Implemented smooth pointer tracking with lerp-based inertial damping
- Bound camera rotation and position offsets to normalized cursor coordinates

## Verification

- [x] Tests pass locally
- [x] Production build succeeds

## Related Issues

Closes #24
