### PR TITLE
feat(home): add keyboard navigation and tests for scroll arrow (closes #36)

### DIFF
--- a/src/components/sections/Home/Home.test.tsx
+++ b/src/components/sections/Home/Home.test.tsx
@@ -44,4 +44,37 @@ describe('Home Section', () => {
     fireEvent.click(contactBtn);
     expect(onNavigate).toHaveBeenCalledWith('contact');
   });
+
+  it('handles scroll arrow click and keyboard activation', () => {
+    const onNavigate = vi.fn();
+    render(<Home onNavigate={onNavigate} />);
+
+    const scrollArrow = screen.getByRole('button', { name: /scroll to about section/i });
+    expect(scrollArrow).toBeInTheDocument();
+
+    fireEvent.click(scrollArrow);
+    expect(onNavigate).toHaveBeenCalledWith('about');
+
+    fireEvent.keyDown(scrollArrow, { key: 'Enter' });
+    expect(onNavigate).toHaveBeenCalledTimes(2);
+
+    fireEvent.keyDown(scrollArrow, { key: ' ' });
+    expect(onNavigate).toHaveBeenCalledTimes(3);
+  });
+
+  it('falls back to scrollIntoView when onNavigate is not provided', () => {
+    const scrollIntoViewMock = vi.fn();
+    const mockEl = document.createElement('div');
+    mockEl.id = 'about';
+    mockEl.scrollIntoView = scrollIntoViewMock;
+    document.body.appendChild(mockEl);
+
+    render(<Home />);
+
+    const scrollArrow = screen.getByRole('button', { name: /scroll to about section/i });
+    fireEvent.click(scrollArrow);
+    expect(scrollIntoViewMock).toHaveBeenCalled();
+
+    document.body.removeChild(mockEl);
+  });
 });

--- a/src/components/sections/Home/Home.tsx
+++ b/src/components/sections/Home/Home.tsx
@@ -186,6 +186,12 @@ export function Home({ onNavigate, theme = 'dark' }: HomeProps) {
       <div 
         className={styles.scrollArrow}
         onClick={scrollToAbout}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            scrollToAbout();
+          }
+        }}
         role="button"
         tabIndex={0}
         aria-label="Scroll to about section"


### PR DESCRIPTION
## Summary

Implements keyboard navigation support for the home scroll indicator arrow and adds unit tests covering keyboard events.

## Changes

- Added Enter/Space key listeners and `tabIndex` to the scroll indicator arrow
- Added unit tests verifying keyboard trigger and scroll event dispatching

## Verification

- [x] Tests pass locally
- [x] Production build succeeds

## Related Issues

Closes #36
