### PR TITLE
feat(skills): add section id assertion to Skills test suite (closes #50)

### DIFF
--- a/src/components/sections/Skills/Skills.test.tsx
+++ b/src/components/sections/Skills/Skills.test.tsx
@@ -48,6 +48,7 @@ describe('Skills', () => {
 
     const section = document.querySelector('section');
     expect(section).toBeInTheDocument();
+    expect(section).toHaveAttribute('id', 'skills');
 
     // Check that each category renders a heading
     const categoryHeadings = screen.getAllByRole('heading', { level: 3 });


### PR DESCRIPTION
## Summary

Adds section DOM ID assertions to the `Skills` component test suite to ensure consistent in-page navigation anchors.

## Changes

- Added assertion verifying `id="skills"` on the root container in `Skills.test.tsx`
- Ensured proper navigation anchor presence

## Verification

- [x] Tests pass locally
- [x] Production build succeeds

## Related Issues

Closes #50
