### PR TITLE
feat(about): expand About test suite with stats and highlights assertions (closes #52)

### DIFF
--- a/src/components/sections/About/About.test.tsx
+++ b/src/components/sections/About/About.test.tsx
@@ -1,10 +1,11 @@
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { About } from './About';
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { About } from "./About";
+import { cvData } from "../../../data/cv";
 
 // Mock framer-motion useScroll & useSpring
-vi.mock('framer-motion', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('framer-motion')>();
+vi.mock("framer-motion", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("framer-motion")>();
   return {
     ...actual,
     useScroll: () => ({
@@ -15,27 +16,38 @@ vi.mock('framer-motion', async (importOriginal) => {
   };
 });
 
-describe('About Section', () => {
+describe("About Section", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('renders about me header, bio content and tags', () => {
+  it("renders about me header, bio content, stats and tags", () => {
     render(<About />);
-    expect(screen.getByRole('heading', { level: 2, name: /About Me/i })).toBeInTheDocument();
-    expect(screen.getByText(/Software Engineer & Creative Developer/i)).toBeInTheDocument();
+    const section = document.getElementById("about");
+    expect(section).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2, name: /About Me/i })).toBeInTheDocument();
+    expect(screen.getByText(cvData.about.title)).toBeInTheDocument();
+
+    cvData.about.stats.forEach((stat) => {
+      expect(screen.getByText(stat.value)).toBeInTheDocument();
+      expect(screen.getByText(stat.label)).toBeInTheDocument();
+    });
+
+    cvData.about.highlights.forEach((highlight) => {
+      expect(screen.getByText(highlight)).toBeInTheDocument();
+    });
   });
 
-  it('renders education cards in the right-aligned layout', () => {
+  it("renders education cards in the right-aligned layout", () => {
     render(<About />);
-    expect(screen.getByLabelText('Education')).toBeInTheDocument();
+    expect(screen.getByLabelText("Education")).toBeInTheDocument();
     expect(screen.getByText(/HiLCoE School of Computer Science/i)).toBeInTheDocument();
     expect(screen.getByText(/Saint Joseph School/i)).toBeInTheDocument();
   });
 
-  it('renders certifications cards cleanly', () => {
+  it("renders certifications cards cleanly", () => {
     render(<About />);
-    expect(screen.getByLabelText('Certifications')).toBeInTheDocument();
+    expect(screen.getByLabelText("Certifications")).toBeInTheDocument();
     expect(screen.getByText(/Bootdev/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

Expands the `About` component test suite to validate the rendering and accessibility of stat counters, highlights, and bio descriptions.

## Changes

- Added unit test assertions for stats counter grid and highlight cards
- Verified text contents, section headings, and layout structure

## Verification

- [x] Tests pass locally
- [x] Production build succeeds

## Related Issues

Closes #52
