### PR TITLE
feat(projects): add section id assertion in Projects test suite (closes #62)

### DIFF
--- a/src/components/sections/Projects/Projects.test.tsx
+++ b/src/components/sections/Projects/Projects.test.tsx
@@ -57,6 +57,11 @@ vi.mock('../../ui/expandable-tabs', () => ({
 }));
 
 describe('Projects', () => {
+  it("renders section with id projects for navigation anchor target", () => {
+    const { container } = render(<Projects />);
+    expect(container.querySelector("section#projects")).toBeInTheDocument();
+  });
+
   it('renders projects and filters by category', () => {
     render(<Projects />);
     expect(screen.getByLabelText('Featured Projects')).toBeTruthy();


### PR DESCRIPTION
## Summary

Adds section DOM ID assertions to the `Projects` component test suite to guarantee proper scroll anchoring and navigation targets.

## Changes

- Added assertion verifying `id="projects"` on the root container in `Projects.test.tsx`
- Verified semantic section hierarchy

## Verification

- [x] Tests pass locally
- [x] Production build succeeds

## Related Issues

Closes #62
