### PR TITLE
fix(build): co-locate React with R3F chunk to prevent useLayoutEffect crash

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,14 +24,20 @@ export default defineConfig({
           if (id.includes('node_modules/three/')) {
             return 'three-core';
           }
-          if (id.includes('node_modules/@react-three/fiber/') || id.includes('node_modules/@react-three/drei/')) {
+          // React must be co-located with R3F — R3F calls useLayoutEffect
+          // at module init time, so React must be in the same chunk to
+          // guarantee it is available before R3F executes.
+          if (
+            id.includes('node_modules/@react-three/fiber/') ||
+            id.includes('node_modules/@react-three/drei/') ||
+            id.includes('node_modules/react/') ||
+            id.includes('node_modules/react-dom/') ||
+            id.includes('node_modules/scheduler/')
+          ) {
             return 'r3f-vendor';
           }
           if (id.includes('node_modules/framer-motion/') || id.includes('node_modules/gsap/') || id.includes('node_modules/animejs/')) {
             return 'animation-vendor';
-          }
-          if (id.includes('node_modules/react/') || id.includes('node_modules/react-dom/') || id.includes('node_modules/scheduler/')) {
-            return 'react-vendor';
           }
         },
       },


### PR DESCRIPTION
## Problem

Production site (portifolio-leul.vercel.app) crashes on load with:

```
Uncaught TypeError: Cannot read properties of undefined (reading "useLayoutEffect")
    at r3f-vendor-C-82iPv9.js:9:807
```

## Root Cause

The manualChunks config in vite.config.ts split React into a separate react-vendor chunk from the r3f-vendor chunk. R3F calls useLayoutEffect at **module initialization time** (not at component render time). When the browser loads and executes the r3f-vendor chunk before react-vendor finishes initializing, React is undefined.

## Fix

Merge react, react-dom, and scheduler into the r3f-vendor chunk so React is guaranteed to be available when R3F initializes.

## Verification

- [x] `bun run build` — produces correct chunk layout (no separate react-vendor)
- [x] `bun x vitest run` — 48 files, 195 tests passing
- [x] `bun run lint` — 0 errors
