### PR TITLE
fix(3d): remove green particle shimmering arrays from background scene

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -100,10 +100,6 @@ vi.mock("./components/BackgroundScene", () => ({
   BackgroundScene: () => <div data-testid="background-scene" />,
 }));
 
-vi.mock("./components/ParticleBackground", () => ({
-  default: () => <div data-testid="particle-background" />,
-}));
-
 vi.mock("./components/sections/Home/Home", () => ({
   Home: () => <div data-testid="home-section">Home Section</div>,
 }));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,6 @@ import { Projects } from './components/sections/Projects/Projects';
 import { Skills } from './components/sections/Skills/Skills';
 import { BackgroundScene } from './components/BackgroundScene';
 import { Preload, ScrollControls, Scroll, useScroll } from '@react-three/drei';
-import ParticleBackground from './components/ParticleBackground';
 import { Contact } from './components/sections/Contact/Contact';
 import { ThemeContext } from './components/sections/theme/ThemeContext';
 import { useGpuTier } from './lib/gateways/gpuTier';
@@ -185,7 +184,6 @@ function App() {
               <ScrollControls pages={scrollPages} damping={0.3}>
                 <ScrollManager onReady={handleScrollElement} />
                 <BackgroundScene theme={theme} particleCount={gpuConfig.particleCount} />
-                <ParticleBackground theme={theme} />
                 <Scroll html style={{ width: '100%' }}>
                   <AnimatePresence mode="wait">
                     {isLoading ? (

--- a/src/components/BackgroundScene.tsx
+++ b/src/components/BackgroundScene.tsx
@@ -4,9 +4,7 @@ import {
   useScroll, 
   Environment, 
   useGLTF,
-  PerspectiveCamera,
-  Points,
-  PointMaterial
+  PerspectiveCamera
 } from '@react-three/drei';
 import * as THREE from 'three';
 import { Theme } from './sections/theme/ThemeContext';
@@ -83,44 +81,6 @@ function Terrain({ surfaceColor }: TerrainProps) {
   );
 }
 
-interface ParticlesProps {
-  color: string;
-  count?: number;
-}
-
-function Particles({ color, count = 1000 }: ParticlesProps) {
-  const positions = useMemo(() => {
-    const positions = new Float32Array(count * 3);
-    for (let i = 0; i < count; i++) {
-      positions[i * 3] = (Math.random() - 0.5) * 50;
-      positions[i * 3 + 1] = Math.random() * 30;
-      positions[i * 3 + 2] = (Math.random() - 0.5) * 50;
-    }
-    return positions;
-  }, [count]);
-
-  return (
-    <Points>
-      <PointMaterial
-        transparent
-        vertexColors
-        size={0.15}
-        sizeAttenuation={true}
-        depthWrite={false}
-        blending={THREE.AdditiveBlending}
-        color={color}
-      />
-      <bufferGeometry>
-        <bufferAttribute
-          attach="attributes-position"
-          count={count}
-          array={positions}
-          itemSize={3}
-        />
-      </bufferGeometry>
-    </Points>
-  );
-}
 
 function ResponsiveTV() {
   return (
@@ -149,7 +109,7 @@ interface BackgroundSceneProps {
   particleCount?: number;
 }
 
-export function BackgroundScene({ theme, particleCount = 1000 }: BackgroundSceneProps) {
+export function BackgroundScene({ theme }: BackgroundSceneProps) {
   const sceneRef = useRef<THREE.Group>(null);
   const prismRef = useRef<THREE.Group>(null);
   const scroll = useScroll();
@@ -294,8 +254,7 @@ export function BackgroundScene({ theme, particleCount = 1000 }: BackgroundScene
           />
         </group>
 
-        {/* Ambient Particles */}
-        <Particles color={palette.highlight} count={particleCount} />
+
 
         <Suspense fallback={null}>
           {/* Character Model */}


### PR DESCRIPTION
## Summary

Removed the green particle field and shimmering additive point arrays from the 3D scene to keep the background clean, crisp, and high contrast.

## Changes

- Removed `ParticleBackground` rendering from `src/App.tsx` and unused mock from `src/App.test.tsx`.
- Removed `Particles` point array component and unused `Points`/`PointMaterial` from `src/components/BackgroundScene.tsx`.

## Verification

- [x] `bun x vitest run` (48 test files, 195 tests pass)
- [x] `bun x tsc --noEmit` (0 typecheck errors)
- [x] `bun run lint` (0 lint errors)
- [x] `bun run build` (production build compiled cleanly)
