### PR TITLE
fix(3d): remove ShorelineBreak ring mesh shimmer array

### DIFF
--- a/src/components/BackgroundScene.test.tsx
+++ b/src/components/BackgroundScene.test.tsx
@@ -56,9 +56,7 @@ vi.mock('@react-three/fiber', () => ({
   },
 }));
 
-// Mock child sub-scenes
 vi.mock('./Ocean', () => ({ Ocean: () => null }));
-vi.mock('./ocean/ShorelineBreak', () => ({ ShorelineBreak: () => null }));
 vi.mock('./TVModel', () => ({ TVModel: () => null }));
 vi.mock('./MeModel', () => ({ MeModel: () => null }));
 

--- a/src/components/BackgroundScene.tsx
+++ b/src/components/BackgroundScene.tsx
@@ -11,7 +11,6 @@ import { Theme } from './sections/theme/ThemeContext';
 import { MeModel } from './MeModel';
 import { TVModel } from './TVModel';
 import { Ocean } from './Ocean';
-import { ShorelineBreak } from './ocean/ShorelineBreak';
 import { getPrefersReducedMotion } from '@/lib/gateways/animationGateway';
 
 const TERRAIN_URL = '/models/terrain-mobile.glb';
@@ -198,9 +197,6 @@ export function BackgroundScene({ theme }: BackgroundSceneProps) {
         <Suspense fallback={null}>
           <Ocean theme={theme} position={[0, -4, 0]} />
         </Suspense>
-
-        {/* Shore break crest lines where waves meet the island edge */}
-        <ShorelineBreak theme={theme} position={[0, -3.92, -20]} />
 
         <Suspense fallback={null}>
           <Terrain surfaceColor={palette.terrain} />


### PR DESCRIPTION
## Summary

Removed the `ShorelineBreak` ring meshes which were generating an unintended oval green/cyan shimmering pillar array across the 3D scene from the projects section down to the footer.

## Changes

- Removed `<ShorelineBreak>` and its import from `src/components/BackgroundScene.tsx`.
- Cleaned up unused mock in `src/components/BackgroundScene.test.tsx`.

## Verification

- [x] `bun x vitest run` (48 test files, 195 tests pass)
- [x] `bun x tsc --noEmit` (0 typecheck errors)
- [x] `bun run lint` (0 lint errors)
- [x] `bun run build` (production build compiled in 4.86s)
