### PR TITLE
fix(3d): replace Ocean water shader with original MeshReflectorMaterial ground and restore particles

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -100,6 +100,10 @@ vi.mock("./components/BackgroundScene", () => ({
   BackgroundScene: () => <div data-testid="background-scene" />,
 }));
 
+vi.mock("./components/ParticleBackground", () => ({
+  default: () => <div data-testid="particle-background" />,
+}));
+
 vi.mock("./components/sections/Home/Home", () => ({
   Home: () => <div data-testid="home-section">Home Section</div>,
 }));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { Projects } from './components/sections/Projects/Projects';
 import { Skills } from './components/sections/Skills/Skills';
 import { BackgroundScene } from './components/BackgroundScene';
 import { Preload, ScrollControls, Scroll, useScroll } from '@react-three/drei';
+import ParticleBackground from './components/ParticleBackground';
 import { Contact } from './components/sections/Contact/Contact';
 import { ThemeContext } from './components/sections/theme/ThemeContext';
 import { useGpuTier } from './lib/gateways/gpuTier';
@@ -184,6 +185,7 @@ function App() {
               <ScrollControls pages={scrollPages} damping={0.3}>
                 <ScrollManager onReady={handleScrollElement} />
                 <BackgroundScene theme={theme} particleCount={gpuConfig.particleCount} />
+                <ParticleBackground theme={theme} />
                 <Scroll html style={{ width: '100%' }}>
                   <AnimatePresence mode="wait">
                     {isLoading ? (

--- a/src/components/BackgroundScene.test.tsx
+++ b/src/components/BackgroundScene.test.tsx
@@ -33,6 +33,7 @@ vi.mock('@react-three/drei', () => ({
   useScroll: vi.fn(() => ({ offset: 0.5 })),
   Environment: () => null,
   PerspectiveCamera: () => null,
+  MeshReflectorMaterial: () => null,
   Points: ({ children }: any) => <>{children}</>,
   PointMaterial: () => null,
 }));
@@ -56,7 +57,6 @@ vi.mock('@react-three/fiber', () => ({
   },
 }));
 
-vi.mock('./Ocean', () => ({ Ocean: () => null }));
 vi.mock('./TVModel', () => ({ TVModel: () => null }));
 vi.mock('./MeModel', () => ({ MeModel: () => null }));
 

--- a/src/components/BackgroundScene.tsx
+++ b/src/components/BackgroundScene.tsx
@@ -3,14 +3,16 @@ import { useFrame } from '@react-three/fiber';
 import { 
   useScroll, 
   Environment, 
+  MeshReflectorMaterial,
   useGLTF,
-  PerspectiveCamera
+  PerspectiveCamera,
+  Points,
+  PointMaterial
 } from '@react-three/drei';
 import * as THREE from 'three';
 import { Theme } from './sections/theme/ThemeContext';
 import { MeModel } from './MeModel';
 import { TVModel } from './TVModel';
-import { Ocean } from './Ocean';
 import { getPrefersReducedMotion } from '@/lib/gateways/animationGateway';
 
 const TERRAIN_URL = '/models/terrain-mobile.glb';
@@ -80,6 +82,44 @@ function Terrain({ surfaceColor }: TerrainProps) {
   );
 }
 
+interface ParticlesProps {
+  color: string;
+  count?: number;
+}
+
+function Particles({ color, count = 1000 }: ParticlesProps) {
+  const positions = useMemo(() => {
+    const positions = new Float32Array(count * 3);
+    for (let i = 0; i < count; i++) {
+      positions[i * 3] = (Math.random() - 0.5) * 50;
+      positions[i * 3 + 1] = Math.random() * 30;
+      positions[i * 3 + 2] = (Math.random() - 0.5) * 50;
+    }
+    return positions;
+  }, [count]);
+
+  return (
+    <Points>
+      <PointMaterial
+        transparent
+        vertexColors
+        size={0.15}
+        sizeAttenuation={true}
+        depthWrite={false}
+        blending={THREE.AdditiveBlending}
+        color={color}
+      />
+      <bufferGeometry>
+        <bufferAttribute
+          attach="attributes-position"
+          count={count}
+          array={positions}
+          itemSize={3}
+        />
+      </bufferGeometry>
+    </Points>
+  );
+}
 
 function ResponsiveTV() {
   return (
@@ -108,7 +148,7 @@ interface BackgroundSceneProps {
   particleCount?: number;
 }
 
-export function BackgroundScene({ theme }: BackgroundSceneProps) {
+export function BackgroundScene({ theme, particleCount = 1000 }: BackgroundSceneProps) {
   const sceneRef = useRef<THREE.Group>(null);
   const prismRef = useRef<THREE.Group>(null);
   const scroll = useScroll();
@@ -193,10 +233,23 @@ export function BackgroundScene({ theme }: BackgroundSceneProps) {
       <group ref={sceneRef}>
         <Environment preset={palette.environment} />
 
-        {/* Realistic Ocean */}
-        <Suspense fallback={null}>
-          <Ocean theme={theme} position={[0, -4, 0]} />
-        </Suspense>
+        {/* Reflective Ground */}
+        <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -4, 0]} receiveShadow>
+          <planeGeometry args={[500, 500]} />
+          <MeshReflectorMaterial
+            blur={[300, 100]}
+            resolution={1024}
+            mixBlur={0.5}
+            mixStrength={10}
+            roughness={0.6}
+            depthScale={1.2}
+            minDepthThreshold={0.4}
+            maxDepthThreshold={1.4}
+            color={palette.ground}
+            metalness={0.9}
+            mirror={0.75}
+          />
+        </mesh>
 
         <Suspense fallback={null}>
           <Terrain surfaceColor={palette.terrain} />
@@ -250,7 +303,8 @@ export function BackgroundScene({ theme }: BackgroundSceneProps) {
           />
         </group>
 
-
+        {/* Ambient Particles */}
+        <Particles color={palette.highlight} count={particleCount} />
 
         <Suspense fallback={null}>
           {/* Character Model */}


### PR DESCRIPTION
## Summary

Replaced the `Ocean` normal-mapped water shader with the original smooth `MeshReflectorMaterial` ground plane, and restored `Particles` and `ParticleBackground`.

## Changes

- Replaced `Ocean` component in `src/components/BackgroundScene.tsx` with `MeshReflectorMaterial` reflective ground.
- Restored `Particles` point field in `src/components/BackgroundScene.tsx`.
- Restored `ParticleBackground` rendering in `src/App.tsx` and unit tests in `src/App.test.tsx` and `src/components/BackgroundScene.test.tsx`.

## Verification

- [x] `bun x vitest run` (48 test files, 195 tests pass)
- [x] `bun x tsc --noEmit` (0 typecheck errors)
- [x] `bun run lint` (0 lint errors)
- [x] `bun run build` (production build compiled in 5.04s)
