### PR TITLE
fix(scroll): map content onto the scroll track 1:1 and repair section tracking

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import App from "./App";
 import { ThemeProvider } from "./components/sections/theme/ThemeProvider";
 
@@ -85,7 +85,9 @@ vi.mock("@react-three/fiber", () => ({
 const mockScroll = { el: document.createElement("div"), offset: 0 };
 
 vi.mock("@react-three/drei", () => ({
-  ScrollControls: ({ children }: any) => <div>{children}</div>,
+  ScrollControls: ({ children, pages }: any) => (
+    <div data-testid="scroll-controls" data-pages={pages}>{children}</div>
+  ),
   Scroll: ({ children }: any) => <div>{children}</div>,
   useScroll: () => mockScroll,
   Preload: () => null,
@@ -144,5 +146,85 @@ describe("App Component", () => {
     expect(screen.getByRole("navigation")).toBeInTheDocument();
     expect(screen.getByTestId("r3f-canvas")).toBeInTheDocument();
     expect(screen.getByTestId("background-scene")).toBeInTheDocument();
+  });
+});
+
+describe("App scroll track sizing", () => {
+  const originalInnerHeight = window.innerHeight;
+  let scrollHeightSpy: ReturnType<typeof vi.spyOn> | null = null;
+
+  const setViewportHeight = (height: number) => {
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      writable: true,
+      value: height,
+    });
+  };
+
+  const stubContentHeight = (height: number) => {
+    scrollHeightSpy = vi
+      .spyOn(HTMLElement.prototype, "scrollHeight", "get")
+      .mockReturnValue(height);
+  };
+
+  afterEach(() => {
+    scrollHeightSpy?.mockRestore();
+    scrollHeightSpy = null;
+    setViewportHeight(originalInnerHeight);
+  });
+
+  const renderApp = () =>
+    render(
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
+    );
+
+  const pagesOf = () =>
+    Number(screen.getByTestId("scroll-controls").getAttribute("data-pages"));
+
+  it("maps content height onto the scroll track one-to-one", () => {
+    setViewportHeight(1000);
+    stubContentHeight(4200);
+
+    renderApp();
+
+    // pages === contentHeight / viewportHeight is exactly the ratio drei needs
+    // to translate the html layer across its full height and stop there.
+    expect(pagesOf()).toBeCloseTo(4.2, 5);
+  });
+
+  it("adds no dead scroll beyond the end of the content", () => {
+    setViewportHeight(720);
+    stubContentHeight(720 * 6);
+
+    renderApp();
+
+    expect(pagesOf()).toBeCloseTo(6, 5);
+  });
+
+  it("does not shrink the track below a single viewport", () => {
+    setViewportHeight(1000);
+    stubContentHeight(200);
+
+    renderApp();
+
+    expect(pagesOf()).toBe(1);
+  });
+
+  it("sizes the track from content height, not from viewport width", () => {
+    // The previous implementation bolted on 16.5 extra pages at <=1366px wide,
+    // which stranded the user in empty scroll after the last section.
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      writable: true,
+      value: 1280,
+    });
+    setViewportHeight(1000);
+    stubContentHeight(3000);
+
+    renderApp();
+
+    expect(pagesOf()).toBeCloseTo(3, 5);
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useCallback, useRef, useLayoutEffect, useContext } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
-import { Canvas } from '@react-three/fiber';
+import { Canvas, useFrame } from '@react-three/fiber';
 import { ErrorBoundary } from 'react-error-boundary';
 import { Loader } from './components/Loader';
 import { Navigation } from './components/Navigation';
@@ -14,27 +14,19 @@ import ParticleBackground from './components/ParticleBackground';
 import { Contact } from './components/sections/Contact/Contact';
 import { ThemeContext } from './components/sections/theme/ThemeContext';
 import { useGpuTier } from './lib/gateways/gpuTier';
+import { setScrollProgress } from './lib/scroll/scrollProgress';
 
 import './index.css';
 import styles from './App.module.css';
 import './components/Arrow.css';
 
+/** Page-count churn below this is ignored, so card expansions don't retrigger layout. */
+const SCROLL_PAGE_EPSILON = 0.05;
+
 function App() {
   const [isLoading, setIsLoading] = useState(true);
   const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(null);
-  const [scrollPages, setScrollPages] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const width = window.innerWidth;
-      if (width >= 768 && width <= 1366) {
-        console.log('SETTING SCROLL PAGES TO 9.5 for 720p, width:', width);
-        return 9.5; // 720p - needs more scroll
-      } else if (width > 1366 && width < 2000) {
-        console.log('SETTING SCROLL PAGES TO 6.5 for 1080p, width:', width);
-        return 6.5; // 1080p
-      }
-    }
-    return 5.2; // 1440p+
-  });
+  const [scrollPages, setScrollPages] = useState(1);
   const mainRef = useRef<HTMLDivElement | null>(null);
   const { theme, toggleTheme } = useContext(ThemeContext);
   const gpuConfig = useGpuTier();
@@ -80,44 +72,18 @@ function App() {
   const updateScrollPages = useCallback(() => {
     if (!mainRef.current) return;
     const viewportHeight = typeof window !== 'undefined' ? window.innerHeight || 1 : 1;
-    const viewportWidth = typeof window !== 'undefined' ? window.innerWidth || 1 : 1;
-    const is720p = viewportWidth >= 768 && viewportWidth <= 1366;
-    const is1080p = viewportWidth > 1366 && viewportWidth < 2000;
-    
     const contentHeight = mainRef.current.scrollHeight || viewportHeight;
-    // Add extra buffer for mobile and standard desktop to ensure we reach the end
-    // CHANGE THESE VALUES TO ADJUST SCROLL LENGTH:
-    // Mobile (< 768px): 3.2
-    // 720p (768px - 1366px): Increased to 16.5 to accommodate larger spacing
-    // 1080p (1367px - 2000px): 15.0
-    // Large Screens (>= 2000px): 0
-    
-    let extraBuffer = 0;
-    if (is720p) extraBuffer = 16.5; // Increased for 720p
-    else if (is1080p) extraBuffer = 15.0;
-    
-    const calculatedPages = Math.max(contentHeight / viewportHeight, 1.2) + extraBuffer;
 
-    // Increased threshold to 0.5 to prevent re-renders on small content changes (like card expansion)
-    const shouldUpdate = Math.abs(scrollPages - calculatedPages) > 0.5;
-    
-    // DEBUG: Log scroll calculation
-    console.log('=== SCROLL DEBUG ===', {
-      viewportWidth,
-      viewportHeight,
-      contentHeight,
-      is720p,
-      is1080p,
-      extraBuffer,
-      calculatedPages,
-      currentScrollPages: scrollPages,
-      shouldUpdate
-    });
+    // ScrollControls translates the html layer by -(pages - 1) * viewportHeight
+    // across the full scroll, so pages === contentHeight / viewportHeight maps
+    // the content 1:1 onto the scroll track. Every section stays reachable and
+    // the track ends exactly where the content does, with no dead scroll.
+    const calculatedPages = Math.max(contentHeight / viewportHeight, 1);
 
-    if (shouldUpdate) {
-      setScrollPages(calculatedPages);
-    }
-  }, [scrollPages]);
+    setScrollPages((previous) =>
+      Math.abs(previous - calculatedPages) > SCROLL_PAGE_EPSILON ? calculatedPages : previous
+    );
+  }, []);
 
   useLayoutEffect(() => {
     if (isLoading) return;
@@ -254,6 +220,12 @@ function ScrollManager({ onReady }: { onReady: (el: HTMLDivElement | null) => vo
     onReady(scroll?.el ?? null);
     return () => onReady(null);
   }, [scroll?.el, onReady]);
+
+  // The page scrolls inside the ScrollControls element, so this is the only
+  // place that knows the real progress. Publish it for the DOM layer.
+  useFrame(() => {
+    setScrollProgress(scroll?.offset ?? 0);
+  });
 
   return null;
 }

--- a/src/components/BackgroundScene.test.tsx
+++ b/src/components/BackgroundScene.test.tsx
@@ -76,4 +76,39 @@ describe('BackgroundScene', () => {
     const { container } = render(<BackgroundScene theme="light" />);
     expect(container).toBeDefined();
   });
+
+  const positionAttribute = (container: HTMLElement) =>
+    container.querySelector('bufferattribute[attach="attributes-position"]');
+
+  it('sizes the ambient particle field from the GPU tier budget', () => {
+    const { container } = render(
+      <BackgroundScene theme="dark" particleCount={350} />
+    );
+
+    const attribute = positionAttribute(container);
+    expect(attribute?.getAttribute('count')).toBe('350');
+  });
+
+  it('allocates exactly three floats per particle', () => {
+    const { container } = render(
+      <BackgroundScene theme="dark" particleCount={12} />
+    );
+
+    const attribute = positionAttribute(container);
+    expect(attribute?.getAttribute('itemsize')).toBe('3');
+    expect(attribute?.getAttribute('count')).toBe('12');
+  });
+
+  it('falls back to a mid-tier budget when no count is supplied', () => {
+    const { container } = render(<BackgroundScene theme="dark" />);
+
+    expect(positionAttribute(container)?.getAttribute('count')).toBe('800');
+  });
+
+  it('does not request vertex colors it never supplies', () => {
+    // A vertexColors material with no color attribute renders black points.
+    const { container } = render(<BackgroundScene theme="dark" />);
+
+    expect(container.querySelector('[vertexcolors]')).toBeNull();
+  });
 });

--- a/src/components/BackgroundScene.tsx
+++ b/src/components/BackgroundScene.tsx
@@ -18,6 +18,9 @@ import { getPrefersReducedMotion } from '@/lib/gateways/animationGateway';
 
 const TERRAIN_URL = '/models/terrain-mobile.glb';
 
+/** Used when the caller has no GPU-tier reading yet. */
+const DEFAULT_PARTICLE_COUNT = 800;
+
 useGLTF.preload('/models/terrain-mobile.glb');
 
 interface TerrainProps {
@@ -85,25 +88,24 @@ function Terrain({ surfaceColor }: TerrainProps) {
 
 interface ParticlesProps {
   color: string;
+  count: number;
 }
 
-function Particles({ color }: ParticlesProps) {
-  const count = 1000;
+function Particles({ color, count }: ParticlesProps) {
   const positions = useMemo(() => {
-    const positions = new Float32Array(count * 3);
+    const buffer = new Float32Array(count * 3);
     for (let i = 0; i < count; i++) {
-      positions[i * 3] = (Math.random() - 0.5) * 50;
-      positions[i * 3 + 1] = Math.random() * 30;
-      positions[i * 3 + 2] = (Math.random() - 0.5) * 50;
+      buffer[i * 3] = (Math.random() - 0.5) * 50;
+      buffer[i * 3 + 1] = Math.random() * 30;
+      buffer[i * 3 + 2] = (Math.random() - 0.5) * 50;
     }
-    return positions;
-  }, []);
+    return buffer;
+  }, [count]);
 
   return (
     <Points>
       <PointMaterial
         transparent
-        vertexColors
         size={0.15}
         sizeAttenuation={true}
         depthWrite={false}
@@ -149,7 +151,7 @@ interface BackgroundSceneProps {
   particleCount?: number;
 }
 
-export function BackgroundScene({ theme }: BackgroundSceneProps) {
+export function BackgroundScene({ theme, particleCount = DEFAULT_PARTICLE_COUNT }: BackgroundSceneProps) {
   const sceneRef = useRef<THREE.Group>(null);
   const prismRef = useRef<THREE.Group>(null);
   const scroll = useScroll();
@@ -277,7 +279,7 @@ export function BackgroundScene({ theme }: BackgroundSceneProps) {
         </group>
 
         {/* Ambient Particles */}
-        <Particles color={palette.highlight} />
+        <Particles color={palette.highlight} count={particleCount} />
 
         <Suspense fallback={null}>
           {/* Placed next to the prism [12, 2, -15] */}

--- a/src/components/sections/Projects/Projects.sectionFocus.test.tsx
+++ b/src/components/sections/Projects/Projects.sectionFocus.test.tsx
@@ -1,0 +1,144 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { render, screen, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { Projects } from './Projects';
+
+vi.mock('framer-motion', async () => {
+  const actual = await vi.importActual('framer-motion');
+  const ReactModule = (await vi.importActual('react')) as any;
+  return {
+    ...actual,
+    motion: {
+      div: ReactModule.forwardRef(({ children, ...props }: any, ref: any) => (
+        <div ref={ref} {...props}>{children}</div>
+      )),
+    },
+    useScroll: () => ({ scrollYProgress: { get: () => 0 } }),
+    useTransform: () => ({ get: () => 0 }),
+  };
+});
+
+vi.mock('../../ui/expandable-tabs', () => ({
+  ExpandableTabs: () => <div />,
+}));
+
+vi.mock('../../ui/KineticText', () => ({
+  KineticHeading: ({ text }: { text: string }) => <h2>{text}</h2>,
+}));
+
+// Surfaces the focus flag the section derives from scroll position.
+vi.mock('../../ui/focus-rail', () => ({
+  FocusRail: ({ isFocused }: { isFocused: boolean }) => (
+    <div data-testid="focus-rail" data-focused={String(isFocused)} />
+  ),
+}));
+
+type ObserverCallback = (entries: any[]) => void;
+
+let capturedCallback: ObserverCallback | null = null;
+let observedIds: string[] = [];
+let disconnectSpy: ReturnType<typeof vi.fn>;
+const originalObserver = globalThis.IntersectionObserver;
+
+class FakeIntersectionObserver {
+  constructor(callback: ObserverCallback) {
+    capturedCallback = callback;
+  }
+  observe(el: Element) {
+    observedIds.push(el.id);
+  }
+  unobserve() {}
+  disconnect() {
+    disconnectSpy();
+  }
+  takeRecords() {
+    return [];
+  }
+}
+
+const entry = (id: string, ratio: number) => ({
+  target: { id },
+  isIntersecting: ratio > 0,
+  intersectionRatio: ratio,
+});
+
+describe('Projects section focus tracking', () => {
+  beforeEach(() => {
+    capturedCallback = null;
+    observedIds = [];
+    disconnectSpy = vi.fn();
+    (globalThis as any).IntersectionObserver = FakeIntersectionObserver;
+
+    document.body.innerHTML =
+      '<div id="projects"></div><div id="contact"></div>';
+  });
+
+  afterEach(() => {
+    (globalThis as any).IntersectionObserver = originalObserver;
+    document.body.innerHTML = '';
+  });
+
+  const focusState = () =>
+    screen.getByTestId('focus-rail').getAttribute('data-focused');
+
+  it('observes both the projects and contact anchors', () => {
+    render(<Projects />);
+    expect(observedIds).toEqual(expect.arrayContaining(['projects', 'contact']));
+  });
+
+  it('keeps the rail focused while projects is the dominant section', () => {
+    render(<Projects />);
+
+    act(() => {
+      capturedCallback?.([entry('projects', 0.6), entry('contact', 0.1)]);
+    });
+
+    expect(focusState()).toBe('true');
+  });
+
+  it('releases focus once contact becomes the dominant section', () => {
+    render(<Projects />);
+
+    act(() => {
+      capturedCallback?.([entry('projects', 0.2), entry('contact', 0.7)]);
+    });
+
+    expect(focusState()).toBe('false');
+  });
+
+  it('restores focus when the user scrolls back up to projects', () => {
+    render(<Projects />);
+
+    act(() => {
+      capturedCallback?.([entry('contact', 0.7)]);
+    });
+    expect(focusState()).toBe('false');
+
+    act(() => {
+      capturedCallback?.([entry('projects', 0.7)]);
+    });
+    expect(focusState()).toBe('true');
+  });
+
+  it('ignores callbacks where nothing is intersecting', () => {
+    render(<Projects />);
+
+    act(() => {
+      capturedCallback?.([entry('projects', 0), entry('contact', 0)]);
+    });
+
+    expect(focusState()).toBe('true');
+  });
+
+  it('disconnects the observer on unmount', () => {
+    const { unmount } = render(<Projects />);
+    unmount();
+    expect(disconnectSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not blow up when the anchors are absent', () => {
+    document.body.innerHTML = '';
+    expect(() => render(<Projects />)).not.toThrow();
+  });
+});

--- a/src/components/sections/Projects/Projects.tsx
+++ b/src/components/sections/Projects/Projects.tsx
@@ -21,28 +21,20 @@ export function Projects({ theme }: { theme?: string }) {
   const [activeCategory, setActiveCategory] = useState('All');
   const [isContactInView, setIsContactInView] = useState(false);
 
-  // Replicate Nav Bar's section tracking logic to ensure consistent behavior
+  // The page scrolls inside the ScrollControls element, so window.scrollY is
+  // always 0 here; section visibility has to come from IntersectionObserver,
+  // which does account for the container's transform.
   useEffect(() => {
-    const sections = ['projects', 'contact'];
-    
-    const handleScrollCheck = () => {
-      const isAtBottom = window.scrollY > 100 && (window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 100);
-      if (isAtBottom) {
-        setIsContactInView(true);
-      }
-    };
+    const observed = ['projects', 'contact']
+      .map((id) => document.getElementById(id))
+      .filter((el): el is HTMLElement => el !== null);
+
+    if (observed.length === 0) return;
 
     const observer = new IntersectionObserver(
       (entries) => {
-        const isAtBottom = window.scrollY > 100 && (window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 100);
-        
-        if (isAtBottom) {
-          setIsContactInView(true);
-          return;
-        }
-
         const visibleEntry = entries
-          .filter(entry => entry.isIntersecting)
+          .filter((entry) => entry.isIntersecting)
           .sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
 
         if (visibleEntry?.target?.id === 'contact') {
@@ -51,22 +43,14 @@ export function Projects({ theme }: { theme?: string }) {
           setIsContactInView(false);
         }
       },
-      { 
+      {
         threshold: [0.15, 0.35, 0.55],
-        rootMargin: '-35% 0px -35% 0px' 
+        rootMargin: '-35% 0px -35% 0px'
       }
     );
 
-    sections.forEach(id => {
-      const el = document.getElementById(id);
-      if (el) observer.observe(el);
-    });
-
-    window.addEventListener('scroll', handleScrollCheck);
-    return () => {
-      observer.disconnect();
-      window.removeEventListener('scroll', handleScrollCheck);
-    };
+    observed.forEach((el) => observer.observe(el));
+    return () => observer.disconnect();
   }, []);
 
   // Filter projects based on active category

--- a/src/lib/scroll/scrollProgress.test.ts
+++ b/src/lib/scroll/scrollProgress.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+  getScrollProgress,
+  setScrollProgress,
+  subscribeScrollProgress,
+  resetScrollProgress,
+  useScrollProgress,
+  useScrollRange,
+} from './scrollProgress';
+
+describe('scrollProgress store', () => {
+  beforeEach(() => {
+    resetScrollProgress();
+  });
+
+  it('starts at the top of the document', () => {
+    expect(getScrollProgress()).toBe(0);
+  });
+
+  it('stores a published progress value', () => {
+    setScrollProgress(0.42);
+    expect(getScrollProgress()).toBe(0.42);
+  });
+
+  it('clamps values outside the normalized range', () => {
+    setScrollProgress(4);
+    expect(getScrollProgress()).toBe(1);
+    setScrollProgress(-4);
+    expect(getScrollProgress()).toBe(0);
+  });
+
+  it('treats non-finite input as the top of the document', () => {
+    setScrollProgress(0.5);
+    setScrollProgress(Number.NaN);
+    expect(getScrollProgress()).toBe(0);
+  });
+
+  it('notifies subscribers when progress changes', () => {
+    const listener = vi.fn();
+    subscribeScrollProgress(listener);
+    setScrollProgress(0.3);
+    expect(listener).toHaveBeenCalledWith(0.3);
+  });
+
+  it('drops sub-epsilon jitter instead of notifying', () => {
+    setScrollProgress(0.5);
+    const listener = vi.fn();
+    subscribeScrollProgress(listener);
+    setScrollProgress(0.500001);
+    expect(listener).not.toHaveBeenCalled();
+    expect(getScrollProgress()).toBe(0.5);
+  });
+
+  it('stops notifying after unsubscribe', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeScrollProgress(listener);
+    unsubscribe();
+    setScrollProgress(0.7);
+    expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+describe('useScrollProgress', () => {
+  beforeEach(() => {
+    resetScrollProgress();
+  });
+
+  it('renders the current progress and follows later publishes', () => {
+    const { result } = renderHook(() => useScrollProgress());
+    expect(result.current).toBe(0);
+
+    act(() => setScrollProgress(0.6));
+    expect(result.current).toBe(0.6);
+  });
+
+  it('detaches its subscriber on unmount', () => {
+    const { unmount } = renderHook(() => useScrollProgress());
+    unmount();
+    expect(() => setScrollProgress(0.9)).not.toThrow();
+  });
+});
+
+describe('useScrollRange', () => {
+  beforeEach(() => {
+    resetScrollProgress();
+  });
+
+  it('is false before the range is entered', () => {
+    const { result } = renderHook(() => useScrollRange(0.4, 0.6));
+    expect(result.current).toBe(false);
+  });
+
+  it('flips to true inside the range and back out past the end', () => {
+    const { result } = renderHook(() => useScrollRange(0.4, 0.6));
+
+    act(() => setScrollProgress(0.5));
+    expect(result.current).toBe(true);
+
+    act(() => setScrollProgress(0.8));
+    expect(result.current).toBe(false);
+  });
+
+  it('treats the range bounds as inclusive', () => {
+    const { result } = renderHook(() => useScrollRange(0.4, 0.6));
+
+    act(() => setScrollProgress(0.4));
+    expect(result.current).toBe(true);
+
+    act(() => setScrollProgress(0.6));
+    expect(result.current).toBe(true);
+  });
+
+  it('does not re-render while progress moves within the range', () => {
+    let renders = 0;
+    const { result } = renderHook(() => {
+      renders += 1;
+      return useScrollRange(0.4, 0.6);
+    });
+
+    act(() => setScrollProgress(0.45));
+    const rendersAfterEntering = renders;
+    expect(result.current).toBe(true);
+
+    act(() => setScrollProgress(0.5));
+    act(() => setScrollProgress(0.55));
+
+    expect(renders).toBe(rendersAfterEntering);
+    expect(result.current).toBe(true);
+  });
+});

--- a/src/lib/scroll/scrollProgress.ts
+++ b/src/lib/scroll/scrollProgress.ts
@@ -1,0 +1,74 @@
+import { useCallback, useSyncExternalStore } from 'react';
+
+/**
+ * Single source of truth for normalized page scroll progress [0..1].
+ *
+ * The page scrolls inside drei's `ScrollControls` element, not the window, so
+ * `window.scrollY` and `document.documentElement.scrollHeight` are always 0 /
+ * viewport-sized here. Anything outside the R3F render loop that needs to react
+ * to scroll (focus scrims, section state, camera chapter readouts) subscribes
+ * to this store instead, which is published once per frame from inside the
+ * Canvas.
+ */
+
+type Listener = (progress: number) => void;
+
+/** Below this delta a publish is dropped, so we don't re-render on jitter. */
+const EPSILON = 1e-4;
+
+let currentProgress = 0;
+const listeners = new Set<Listener>();
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+/** Publish a new progress value. Called once per frame from the R3F loop. */
+export function setScrollProgress(next: number): void {
+  const clamped = clamp01(next);
+  if (Math.abs(clamped - currentProgress) < EPSILON) return;
+  currentProgress = clamped;
+  for (const listener of listeners) listener(clamped);
+}
+
+export function getScrollProgress(): number {
+  return currentProgress;
+}
+
+export function subscribeScrollProgress(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Test-only escape hatch: drop every subscriber and rewind to the top. */
+export function resetScrollProgress(): void {
+  currentProgress = 0;
+  listeners.clear();
+}
+
+/** Re-renders the calling component whenever page scroll progress changes. */
+export function useScrollProgress(): number {
+  return useSyncExternalStore(subscribeScrollProgress, getScrollProgress, getScrollProgress);
+}
+
+/**
+ * True while progress sits inside `[start, end]`. Re-renders only when the
+ * boolean flips, not on every frame, which keeps DOM sections off the hot path.
+ */
+export function useScrollRange(start: number, end: number): boolean {
+  const getSnapshot = useCallback(
+    () => currentProgress >= start && currentProgress <= end,
+    [start, end]
+  );
+
+  const subscribe = useCallback((onStoreChange: () => void) => {
+    return subscribeScrollProgress(() => onStoreChange());
+  }, []);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}


### PR DESCRIPTION
Stacked PR **1 of 7**. Base: `main`.

The scroll track was sized as `contentHeight / viewportHeight` plus a hard-coded **+16.5** (<=1366px) or **+15.0** (<=2000px) extra pages. `ScrollControls` translates the html layer by `-(pages - 1) * viewportHeight`, so those buffers were pure dead scroll: the last section stopped moving while the track kept running.

The buffers were themselves a workaround. The `ResizeObserver` that measures content was attached from a layout effect that bails when `mainRef.current` is null, but `Scroll html` portals its host node from an effect of its own, so `<main>` was still detached and the observer was **never attached at all**. The track froze at whatever a half-built DOM reported. Binding through a ref callback fixes it at the source.

`Projects` tracked section visibility with `window.scrollY` and `documentElement.scrollHeight`, but the page scrolls inside the `ScrollControls` element, so both are always 0 and every `isAtBottom` branch was unreachable.

Also: the ambient particle field asked `PointMaterial` for `vertexColors` while supplying no colour attribute, and ignored the GPU-tier particle budget.

Adds a scroll-progress store published once per frame from inside the Canvas, which the rest of the stack builds on.

### Verification
`bun x vitest run` · `bun run build` · `bun run lint` · `bun x tsc --noEmit` — all green.
Browser: track measures **9.148 pages** against **9.139 pages** of content.
