### PR TITLE
feat(camera): scrub a cinematic spline instead of spinning the whole world

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "portfolio-dev",
+      "runtimeExecutable": "bun",
+      "runtimeArgs": ["run", "dev"],
+      "port": 8080
+    }
+  ]
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useRef, useLayoutEffect, useContext } from 'react';
+import { useEffect, useState, useCallback, useRef, useContext } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { ErrorBoundary } from 'react-error-boundary';
@@ -27,7 +27,8 @@ function App() {
   const [isLoading, setIsLoading] = useState(true);
   const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(null);
   const [scrollPages, setScrollPages] = useState(1);
-  const mainRef = useRef<HTMLDivElement | null>(null);
+  const mainRef = useRef<HTMLElement | null>(null);
+  const contentObserverRef = useRef<ResizeObserver | null>(null);
   const { theme, toggleTheme } = useContext(ThemeContext);
   const gpuConfig = useGpuTier();
 
@@ -85,25 +86,38 @@ function App() {
     );
   }, []);
 
-  useLayoutEffect(() => {
-    if (isLoading) return;
+  // Measuring from an effect is unreliable here: `Scroll html` portals its host
+  // node from an effect of its own, so <main> is often still detached when a
+  // layout effect runs. A one-shot measurement then freezes the track at
+  // whatever the half-built DOM reported, and nothing ever re-measures.
+  // Binding through a ref callback attaches the observer exactly when the node
+  // appears, however late that is.
+  const attachMain = useCallback((node: HTMLElement | null) => {
+    contentObserverRef.current?.disconnect();
+    contentObserverRef.current = null;
+    mainRef.current = node;
+
+    if (!node) return;
+
+    if (typeof ResizeObserver !== 'undefined') {
+      const observer = new ResizeObserver(() => updateScrollPages());
+      observer.observe(node);
+      contentObserverRef.current = observer;
+    }
+
     updateScrollPages();
+  }, [updateScrollPages]);
 
-    const mainElement = mainRef.current;
-    if (!mainElement) return;
-
-    const observer = typeof ResizeObserver !== 'undefined'
-      ? new ResizeObserver(() => updateScrollPages())
-      : null;
-
-    observer?.observe(mainElement);
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
     window.addEventListener('resize', updateScrollPages);
+    return () => window.removeEventListener('resize', updateScrollPages);
+  }, [updateScrollPages]);
 
-    return () => {
-      observer?.disconnect();
-      window.removeEventListener('resize', updateScrollPages);
-    };
-  }, [isLoading, updateScrollPages]);
+  useEffect(() => () => {
+    contentObserverRef.current?.disconnect();
+    contentObserverRef.current = null;
+  }, []);
 
   const scrollToSection = useCallback((id: string) => {
     const target = document.getElementById(id);
@@ -164,7 +178,7 @@ function App() {
                 <ParticleBackground theme={theme} />
                 <Scroll html style={{ width: '100%' }}>
                   {!isLoading && (
-                    <main ref={mainRef} className={styles.main}>
+                    <main ref={attachMain} className={styles.main}>
                       <Home onNavigate={scrollToSection} />
                       <div id="homeToAboutArrow" onClick={() => scrollToSection('about')}>
                         <div className="curveWrapper">

--- a/src/components/3d/CinematicCameraController.test.tsx
+++ b/src/components/3d/CinematicCameraController.test.tsx
@@ -1,0 +1,182 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as THREE from 'three';
+import { CinematicCameraController } from './CinematicCameraController';
+import { CAMERA_CHAPTERS, CAMERA_ARC_END } from '@/lib/camera/cinematicSpline';
+
+const camera = new THREE.PerspectiveCamera(50, 16 / 9, 0.1, 1000);
+
+// Shared and mutated in place: the component captures this object once at
+// render, exactly as the real useScroll hook behaves.
+const scrollState = { offset: 0 };
+let pointer = { x: 0, y: 0 };
+let frameCallback: ((state: any, delta: number) => void) | null = null;
+
+vi.mock('@react-three/fiber', () => ({
+  useThree: (selector?: (state: any) => unknown) => {
+    const state = { camera, size: { width: 1920, height: 1080 } };
+    return selector ? selector(state) : state;
+  },
+  useFrame: (callback: (state: any, delta: number) => void) => {
+    frameCallback = callback;
+  },
+}));
+
+vi.mock('@react-three/drei', () => ({
+  useScroll: () => scrollState,
+}));
+
+const reducedMotion = vi.fn(() => false);
+vi.mock('@/lib/gateways/animationGateway', () => ({
+  getPrefersReducedMotion: () => reducedMotion(),
+}));
+
+/** Runs `count` frames of the loop, which is how damping is meant to converge. */
+const advance = (count = 1, delta = 0.016) => {
+  for (let i = 0; i < count; i += 1) {
+    frameCallback?.({ mouse: pointer, clock: { getElapsedTime: () => i * delta } }, delta);
+  }
+};
+
+const mount = (props: Record<string, unknown> = {}) =>
+  render(<CinematicCameraController {...props} />);
+
+const chapterVec = (index: number) =>
+  new THREE.Vector3(...CAMERA_CHAPTERS[index].position);
+
+describe('CinematicCameraController', () => {
+  beforeEach(() => {
+    scrollState.offset = 0;
+    pointer = { x: 0, y: 0 };
+    frameCallback = null;
+    reducedMotion.mockReturnValue(false);
+    camera.position.set(0, 0, 0);
+    camera.quaternion.identity();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing into the DOM', () => {
+    const { container } = mount();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('takes the opening shot on the first frame instead of easing in', () => {
+    mount({ mouseSway: 0 });
+    advance(1);
+
+    expect(camera.position.distanceTo(chapterVec(0))).toBeCloseTo(0, 5);
+  });
+
+  it('travels toward the closing shot as the arc completes', () => {
+    mount({ mouseSway: 0 });
+    advance(1);
+
+    scrollState.offset = CAMERA_ARC_END;
+    advance(400);
+
+    const last = chapterVec(CAMERA_CHAPTERS.length - 1);
+    expect(camera.position.distanceTo(last)).toBeLessThan(0.05);
+  });
+
+  it('holds the closing shot for every scroll past the arc end', () => {
+    mount({ mouseSway: 0 });
+    advance(1);
+
+    scrollState.offset = CAMERA_ARC_END;
+    advance(400);
+    const atArcEnd = camera.position.clone();
+
+    // This is the seamless-continuation guarantee: the DOM keeps scrolling,
+    // the viewpoint does not drift or overshoot.
+    scrollState.offset = 1;
+    advance(200);
+
+    expect(camera.position.distanceTo(atArcEnd)).toBeLessThan(1e-6);
+  });
+
+  it('eases between shots rather than snapping', () => {
+    mount({ mouseSway: 0 });
+    advance(1);
+    const opening = camera.position.clone();
+
+    scrollState.offset = CAMERA_ARC_END;
+    advance(1);
+
+    const moved = opening.distanceTo(camera.position);
+    const total = opening.distanceTo(chapterVec(CAMERA_CHAPTERS.length - 1));
+    expect(moved).toBeGreaterThan(0);
+    expect(moved).toBeLessThan(total * 0.5);
+  });
+
+  it('offsets the viewpoint with the pointer', () => {
+    mount({ mouseSway: 2 });
+    pointer = { x: 1, y: 0 };
+    advance(1);
+
+    expect(camera.position.x).toBeCloseTo(CAMERA_CHAPTERS[0].position[0] + 2, 5);
+  });
+
+  it('leaves the viewpoint unswayed when pointer parallax is disabled', () => {
+    mount({ mouseSway: 0 });
+    pointer = { x: 1, y: 1 };
+    advance(1);
+
+    expect(camera.position.distanceTo(chapterVec(0))).toBeCloseTo(0, 5);
+  });
+
+  it('tolerates a frame state with no pointer', () => {
+    mount();
+    expect(() => frameCallback?.({ clock: { getElapsedTime: () => 0 } }, 0.016)).not.toThrow();
+  });
+
+  it('clamps a long frame delta so a backgrounded tab cannot teleport the camera', () => {
+    mount({ mouseSway: 0 });
+    advance(1);
+    const opening = camera.position.clone();
+
+    scrollState.offset = CAMERA_ARC_END;
+    // One frame with a 30s delta, as a restored tab reports.
+    frameCallback?.({ mouse: pointer, clock: { getElapsedTime: () => 30 } }, 30);
+    const jumped = opening.distanceTo(camera.position);
+
+    camera.position.copy(opening);
+    frameCallback?.({ mouse: pointer, clock: { getElapsedTime: () => 30 } }, 0.1);
+    const clamped = opening.distanceTo(camera.position);
+
+    expect(jumped).toBeCloseTo(clamped, 5);
+  });
+
+  describe('reduced motion', () => {
+    beforeEach(() => reducedMotion.mockReturnValue(true));
+
+    it('cuts straight to the nearest authored shot with no easing', () => {
+      mount();
+      scrollState.offset = CAMERA_ARC_END;
+      advance(1);
+
+      const last = chapterVec(CAMERA_CHAPTERS.length - 1);
+      expect(camera.position.distanceTo(last)).toBeCloseTo(0, 5);
+    });
+
+    it('snaps between discrete chapters rather than scrubbing continuously', () => {
+      mount();
+      scrollState.offset = CAMERA_ARC_END * 0.5;
+      advance(1);
+
+      // Midway through the arc lands exactly on chapter 2, not between shots.
+      expect(camera.position.distanceTo(chapterVec(2))).toBeCloseTo(0, 5);
+    });
+
+    it('ignores pointer parallax entirely', () => {
+      mount({ mouseSway: 5 });
+      pointer = { x: 1, y: 1 };
+      advance(1);
+
+      expect(camera.position.distanceTo(chapterVec(0))).toBeCloseTo(0, 5);
+    });
+  });
+});

--- a/src/components/3d/CinematicCameraController.tsx
+++ b/src/components/3d/CinematicCameraController.tsx
@@ -1,0 +1,98 @@
+import { useMemo, useRef } from 'react';
+import { useFrame, useThree } from '@react-three/fiber';
+import { useScroll } from '@react-three/drei';
+import * as THREE from 'three';
+import {
+  CAMERA_ARC_END,
+  createCameraSpline,
+  mapScrollToArc,
+  nearestChapterIndex,
+  sampleCameraPose,
+  sampleChapterPose,
+} from '@/lib/camera/cinematicSpline';
+import { getPrefersReducedMotion } from '@/lib/gateways/animationGateway';
+
+/**
+ * Scrubs the camera along the cinematic spline as the page scrolls, and parks
+ * it on the final shot once the arc completes so the DOM layer can keep
+ * scrolling underneath. Scene objects are never touched.
+ */
+
+// Module-scope scratch. Allocating inside useFrame would churn the GC at 60fps.
+const desiredPosition = new THREE.Vector3();
+const desiredTarget = new THREE.Vector3();
+const smoothedTarget = new THREE.Vector3();
+
+/** Higher converges faster. Tuned so a flick of the wheel still reads as a move. */
+const POSITION_DAMPING = 3.2;
+const TARGET_DAMPING = 4;
+
+/** World units the viewpoint drifts at the edges of the pointer range. */
+const DEFAULT_MOUSE_SWAY = 1.6;
+
+/** A backgrounded tab hands back a huge delta; clamp so the camera never snaps. */
+const MAX_FRAME_DELTA = 0.1;
+
+export interface CinematicCameraControllerProps {
+  /** Scroll progress at which the camera arc completes and holds. */
+  arcEnd?: number;
+  /** World units of pointer parallax. Zero disables pointer response. */
+  mouseSway?: number;
+}
+
+export function CinematicCameraController({
+  arcEnd = CAMERA_ARC_END,
+  mouseSway = DEFAULT_MOUSE_SWAY,
+}: CinematicCameraControllerProps = {}) {
+  const camera = useThree((state) => state.camera);
+  const scroll = useScroll();
+  const spline = useMemo(() => createCameraSpline(), []);
+  const hasSettled = useRef(false);
+
+  useFrame((state, delta) => {
+    if (!camera) return;
+
+    const reducedMotion = getPrefersReducedMotion();
+    const arc = mapScrollToArc(scroll?.offset ?? 0, arcEnd);
+
+    if (reducedMotion) {
+      // Discrete cuts between authored shots: no scrubbing, no pointer drift.
+      sampleChapterPose(nearestChapterIndex(arc), desiredPosition, desiredTarget);
+      camera.position.copy(desiredPosition);
+      smoothedTarget.copy(desiredTarget);
+      camera.lookAt(smoothedTarget);
+      hasSettled.current = true;
+      return;
+    }
+
+    sampleCameraPose(spline, arc, desiredPosition, desiredTarget);
+
+    const pointerX = state.mouse?.x ?? 0;
+    const pointerY = state.mouse?.y ?? 0;
+    desiredPosition.x += pointerX * mouseSway;
+    desiredPosition.y += pointerY * mouseSway * 0.5;
+
+    if (!hasSettled.current) {
+      // First frame: take the shot as authored rather than easing in from the
+      // default camera position, which would read as an unintended fly-in.
+      camera.position.copy(desiredPosition);
+      smoothedTarget.copy(desiredTarget);
+      hasSettled.current = true;
+    } else {
+      const step = Math.min(delta ?? 0, MAX_FRAME_DELTA);
+      const { damp } = THREE.MathUtils;
+
+      camera.position.x = damp(camera.position.x, desiredPosition.x, POSITION_DAMPING, step);
+      camera.position.y = damp(camera.position.y, desiredPosition.y, POSITION_DAMPING, step);
+      camera.position.z = damp(camera.position.z, desiredPosition.z, POSITION_DAMPING, step);
+
+      smoothedTarget.x = damp(smoothedTarget.x, desiredTarget.x, TARGET_DAMPING, step);
+      smoothedTarget.y = damp(smoothedTarget.y, desiredTarget.y, TARGET_DAMPING, step);
+      smoothedTarget.z = damp(smoothedTarget.z, desiredTarget.z, TARGET_DAMPING, step);
+    }
+
+    camera.lookAt(smoothedTarget);
+  });
+
+  return null;
+}

--- a/src/components/BackgroundScene.test.tsx
+++ b/src/components/BackgroundScene.test.tsx
@@ -39,20 +39,25 @@ vi.mock('@react-three/drei', () => ({
 }));
 
 // Mock Fiber
+// A real camera, so components that drive position/lookAt are exercised for
+// real rather than against a stub that silently accepts anything.
+const testCamera = new THREE.PerspectiveCamera(50, 16 / 9, 0.1, 1000);
+
 vi.mock('@react-three/fiber', () => ({
-  useThree: () => ({
-    camera: {
-      fov: 50,
-      position: { set: vi.fn() },
-      updateProjectionMatrix: vi.fn(),
-    },
-    size: { width: 1920, height: 1080 },
-  }),
+  // The real useThree applies a selector; the stub used to ignore it and hand
+  // back the whole state object.
+  useThree: (selector?: (state: any) => unknown) => {
+    const state = {
+      camera: testCamera,
+      size: { width: 1920, height: 1080 },
+    };
+    return selector ? selector(state) : state;
+  },
   useFrame: (callback: (state: any, delta?: number) => void) => {
     callback({
       clock: { getElapsedTime: () => 1.5 },
       mouse: { x: 0.5, y: -0.2 },
-      camera: { position: { x: 0, y: 5, z: 30 } },
+      camera: testCamera,
     }, 0.016);
   },
 }));

--- a/src/components/BackgroundScene.tsx
+++ b/src/components/BackgroundScene.tsx
@@ -1,7 +1,6 @@
 import { useRef, useMemo, useEffect, Suspense } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { 
-  useScroll, 
   Environment, 
   useGLTF,
   PerspectiveCamera,
@@ -14,6 +13,7 @@ import { MeModel } from './MeModel';
 import { TVModel } from './TVModel';
 import { Ocean } from './Ocean';
 import { ShorelineBreak } from './ocean/ShorelineBreak';
+import { CinematicCameraController } from './3d/CinematicCameraController';
 import { getPrefersReducedMotion } from '@/lib/gateways/animationGateway';
 
 const TERRAIN_URL = '/models/terrain-mobile.glb';
@@ -152,9 +152,7 @@ interface BackgroundSceneProps {
 }
 
 export function BackgroundScene({ theme, particleCount = DEFAULT_PARTICLE_COUNT }: BackgroundSceneProps) {
-  const sceneRef = useRef<THREE.Group>(null);
   const prismRef = useRef<THREE.Group>(null);
-  const scroll = useScroll();
 
   const isLight = theme === 'light';
 
@@ -193,29 +191,24 @@ export function BackgroundScene({ theme, particleCount = DEFAULT_PARTICLE_COUNT 
   }, [isLight]);
 
   useFrame((state) => {
-    if (!sceneRef.current || !prismRef.current) return;
+    if (!prismRef.current) return;
 
     const time = state.clock.getElapsedTime();
-    const scrollProgress = scroll?.offset ?? 0;
     const reducedMotion = getPrefersReducedMotion();
 
-    // Scene parallax based on mouse
-    const mouseX = reducedMotion ? 0 : state.mouse.x * 0.3;
-    const mouseY = reducedMotion ? 0 : state.mouse.y * 0.2;
-    sceneRef.current.rotation.y = mouseX * 0.2 + scrollProgress * Math.PI;
-    sceneRef.current.rotation.x = mouseY * 0.1;
-
-    // Prism animation
+    // Parallax now lives on the camera, not on this group: rotating the world
+    // to fake it displaced every authored object placement along with it.
     prismRef.current.position.y = reducedMotion ? 2 : Math.sin(time * 0.5) * 0.2 + 2;
   });
 
   return (
     <>
       <ResponsiveCamera />
+      <CinematicCameraController />
       <color attach="background" args={[palette.background]} />
       <fog attach="fog" args={[palette.fog, 30, 70]} />
 
-      <group ref={sceneRef}>
+      <group>
         <Environment preset={palette.environment} />
 
         {/* Realistic Ocean */}

--- a/src/lib/camera/cinematicSpline.test.ts
+++ b/src/lib/camera/cinematicSpline.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import {
+  CAMERA_ARC_END,
+  CAMERA_CHAPTERS,
+  createCameraSpline,
+  mapScrollToArc,
+  nearestChapterIndex,
+  sampleCameraPose,
+  sampleChapterPose,
+} from './cinematicSpline';
+
+describe('CAMERA_CHAPTERS', () => {
+  it('covers every scrolled section anchor in document order', () => {
+    expect(CAMERA_CHAPTERS.map((c) => c.id)).toEqual([
+      'home',
+      'about',
+      'skills',
+      'projects',
+      'contact',
+    ]);
+  });
+
+  it('never places the camera below the ocean plane at y = -4', () => {
+    for (const chapter of CAMERA_CHAPTERS) {
+      expect(chapter.position[1]).toBeGreaterThan(-4);
+    }
+  });
+
+  it('always frames a point in front of the camera, not behind it', () => {
+    for (const chapter of CAMERA_CHAPTERS) {
+      expect(chapter.target[2]).toBeLessThan(chapter.position[2]);
+    }
+  });
+
+  it('completes the arc before the page runs out of scroll', () => {
+    expect(CAMERA_ARC_END).toBeGreaterThan(0);
+    expect(CAMERA_ARC_END).toBeLessThan(1);
+  });
+});
+
+describe('mapScrollToArc', () => {
+  it('starts the arc at the top of the page', () => {
+    expect(mapScrollToArc(0)).toBe(0);
+  });
+
+  it('rescales scroll onto the arc range', () => {
+    expect(mapScrollToArc(0.25, 0.5)).toBe(0.5);
+  });
+
+  it('completes the arc exactly at arcEnd', () => {
+    expect(mapScrollToArc(0.5, 0.5)).toBe(1);
+  });
+
+  it('holds the final shot for all scroll past arcEnd', () => {
+    // This is what lets the DOM keep scrolling after the 3D travel finishes.
+    expect(mapScrollToArc(0.75, 0.5)).toBe(1);
+    expect(mapScrollToArc(1, 0.5)).toBe(1);
+  });
+
+  it('clamps negative and non-finite scroll to the start', () => {
+    expect(mapScrollToArc(-1)).toBe(0);
+    expect(mapScrollToArc(Number.NaN)).toBe(0);
+  });
+
+  it('treats a zero-length arc as already complete', () => {
+    expect(mapScrollToArc(0.5, 0)).toBe(1);
+  });
+});
+
+describe('nearestChapterIndex', () => {
+  it('snaps to the first chapter at the start', () => {
+    expect(nearestChapterIndex(0)).toBe(0);
+  });
+
+  it('snaps to the last chapter at the end', () => {
+    expect(nearestChapterIndex(1)).toBe(CAMERA_CHAPTERS.length - 1);
+  });
+
+  it('snaps to the closest interior chapter', () => {
+    expect(nearestChapterIndex(0.5, 5)).toBe(2);
+    expect(nearestChapterIndex(0.26, 5)).toBe(1);
+  });
+
+  it('clamps out-of-range and non-finite progress', () => {
+    expect(nearestChapterIndex(-2)).toBe(0);
+    expect(nearestChapterIndex(9)).toBe(CAMERA_CHAPTERS.length - 1);
+    expect(nearestChapterIndex(Number.NaN)).toBe(0);
+  });
+
+  it('handles a single-chapter list without going negative', () => {
+    expect(nearestChapterIndex(1, 1)).toBe(0);
+  });
+});
+
+describe('createCameraSpline', () => {
+  it('rejects a spline that cannot be interpolated', () => {
+    expect(() => createCameraSpline([CAMERA_CHAPTERS[0]])).toThrow(
+      /at least two chapters/
+    );
+  });
+
+  it('builds open curves through every authored chapter', () => {
+    const spline = createCameraSpline();
+    expect(spline.positionCurve.points).toHaveLength(CAMERA_CHAPTERS.length);
+    expect(spline.targetCurve.points).toHaveLength(CAMERA_CHAPTERS.length);
+    expect(spline.positionCurve.closed).toBe(false);
+  });
+});
+
+describe('sampleCameraPose', () => {
+  const spline = createCameraSpline();
+  const position = new THREE.Vector3();
+  const target = new THREE.Vector3();
+
+  it('lands on the first authored shot at t = 0', () => {
+    sampleCameraPose(spline, 0, position, target);
+    expect(position.toArray()).toEqual([...CAMERA_CHAPTERS[0].position]);
+    expect(target.toArray()).toEqual([...CAMERA_CHAPTERS[0].target]);
+  });
+
+  it('lands on the last authored shot at t = 1', () => {
+    sampleCameraPose(spline, 1, position, target);
+    const last = CAMERA_CHAPTERS[CAMERA_CHAPTERS.length - 1];
+    expect(position.x).toBeCloseTo(last.position[0], 5);
+    expect(position.y).toBeCloseTo(last.position[1], 5);
+    expect(position.z).toBeCloseTo(last.position[2], 5);
+  });
+
+  it('clamps out-of-range progress instead of extrapolating off the curve', () => {
+    const overrun = new THREE.Vector3();
+    const overrunTarget = new THREE.Vector3();
+    sampleCameraPose(spline, 4, overrun, overrunTarget);
+    sampleCameraPose(spline, 1, position, target);
+    expect(overrun.distanceTo(position)).toBeCloseTo(0, 5);
+  });
+
+  it('treats non-finite progress as the start of the arc', () => {
+    sampleCameraPose(spline, Number.NaN, position, target);
+    expect(position.toArray()).toEqual([...CAMERA_CHAPTERS[0].position]);
+  });
+
+  it('writes into the caller vectors rather than allocating', () => {
+    const reused = new THREE.Vector3();
+    const reusedTarget = new THREE.Vector3();
+    sampleCameraPose(spline, 0.4, reused, reusedTarget);
+    const identity = reused;
+    sampleCameraPose(spline, 0.8, reused, reusedTarget);
+    expect(reused).toBe(identity);
+  });
+
+  it('moves the viewpoint continuously across the arc', () => {
+    const a = new THREE.Vector3();
+    const b = new THREE.Vector3();
+    const scratch = new THREE.Vector3();
+
+    sampleCameraPose(spline, 0.3, a, scratch);
+    sampleCameraPose(spline, 0.31, b, scratch);
+
+    expect(a.distanceTo(b)).toBeGreaterThan(0);
+    expect(a.distanceTo(b)).toBeLessThan(5);
+  });
+});
+
+describe('sampleChapterPose', () => {
+  const position = new THREE.Vector3();
+  const target = new THREE.Vector3();
+
+  it('returns the exact authored shot for a chapter', () => {
+    sampleChapterPose(3, position, target);
+    expect(position.toArray()).toEqual([...CAMERA_CHAPTERS[3].position]);
+    expect(target.toArray()).toEqual([...CAMERA_CHAPTERS[3].target]);
+  });
+
+  it('clamps indices outside the chapter list', () => {
+    sampleChapterPose(-5, position, target);
+    expect(position.toArray()).toEqual([...CAMERA_CHAPTERS[0].position]);
+
+    sampleChapterPose(99, position, target);
+    const last = CAMERA_CHAPTERS[CAMERA_CHAPTERS.length - 1];
+    expect(position.toArray()).toEqual([...last.position]);
+  });
+});

--- a/src/lib/camera/cinematicSpline.ts
+++ b/src/lib/camera/cinematicSpline.ts
@@ -1,0 +1,119 @@
+import * as THREE from 'three';
+
+/**
+ * Camera choreography for the scroll-driven 3D chapters.
+ *
+ * The scene's object placements are authored fixed; nothing here moves them.
+ * Only the viewpoint travels, along a Catmull-Rom spline sampled from the
+ * page's normalized scroll progress.
+ */
+
+export interface CameraChapter {
+  /** Section anchor this shot belongs to, for debugging and readouts. */
+  readonly id: string;
+  /** Where the camera sits. */
+  readonly position: readonly [number, number, number];
+  /** What the camera frames. */
+  readonly target: readonly [number, number, number];
+}
+
+/**
+ * Scroll progress at which the camera arc completes. Past this point the
+ * viewpoint holds its final shot while the DOM layer keeps scrolling, so the
+ * page never feels like it has hit a wall when the 3D travel runs out.
+ */
+export const CAMERA_ARC_END = 0.62;
+
+export const CAMERA_CHAPTERS: readonly CameraChapter[] = [
+  // Hero: high isometric establishing shot over the whole island.
+  { id: 'home', position: [0, 12, 34], target: [0, 0, -14] },
+  // About: swing left and drop to eye level, framing the CRT.
+  { id: 'about', position: [-15, 4.5, 8], target: [-10, 0.5, -14] },
+  // Skills: diagonal pull-back across the terrain ridge.
+  { id: 'skills', position: [5, 9, 18], target: [0, -1, -18] },
+  // Projects: low three-quarter on the prism and avatar side.
+  { id: 'projects', position: [21, 2.5, 9], target: [15, 0, -15] },
+  // Contact: settle onto the horizon and hand off to the DOM.
+  { id: 'contact', position: [0, 6.5, 26], target: [0, 2, -30] },
+] as const;
+
+export interface CameraSpline {
+  readonly positionCurve: THREE.CatmullRomCurve3;
+  readonly targetCurve: THREE.CatmullRomCurve3;
+}
+
+export function createCameraSpline(
+  chapters: readonly CameraChapter[] = CAMERA_CHAPTERS
+): CameraSpline {
+  if (chapters.length < 2) {
+    throw new Error('A camera spline needs at least two chapters.');
+  }
+
+  const toPoints = (pick: (c: CameraChapter) => readonly [number, number, number]) =>
+    chapters.map((chapter) => new THREE.Vector3(...pick(chapter)));
+
+  return {
+    positionCurve: new THREE.CatmullRomCurve3(
+      toPoints((c) => c.position),
+      false,
+      'catmullrom',
+      0.5
+    ),
+    targetCurve: new THREE.CatmullRomCurve3(
+      toPoints((c) => c.target),
+      false,
+      'catmullrom',
+      0.5
+    ),
+  };
+}
+
+/**
+ * Rescales page scroll onto the camera arc and clamps it. Scroll past
+ * `arcEnd` returns 1, which parks the camera on its final shot.
+ */
+export function mapScrollToArc(scrollProgress: number, arcEnd: number = CAMERA_ARC_END): number {
+  if (!Number.isFinite(scrollProgress) || scrollProgress <= 0) return 0;
+  if (arcEnd <= 0) return 1;
+  const arc = scrollProgress / arcEnd;
+  return arc >= 1 ? 1 : arc;
+}
+
+/** Nearest authored shot, used to jump discretely under reduced motion. */
+export function nearestChapterIndex(
+  arcProgress: number,
+  chapterCount: number = CAMERA_CHAPTERS.length
+): number {
+  const lastIndex = Math.max(chapterCount - 1, 0);
+  if (!Number.isFinite(arcProgress) || arcProgress <= 0) return 0;
+  if (arcProgress >= 1) return lastIndex;
+  return Math.round(arcProgress * lastIndex);
+}
+
+/**
+ * Writes the pose at `arcProgress` into the caller's vectors. Takes output
+ * parameters so the render loop can reuse scratch objects and allocate nothing.
+ */
+export function sampleCameraPose(
+  spline: CameraSpline,
+  arcProgress: number,
+  outPosition: THREE.Vector3,
+  outTarget: THREE.Vector3
+): void {
+  const t = Number.isFinite(arcProgress) ? Math.min(1, Math.max(0, arcProgress)) : 0;
+  spline.positionCurve.getPoint(t, outPosition);
+  spline.targetCurve.getPoint(t, outTarget);
+}
+
+/** Writes the exact authored pose for a chapter, bypassing the spline. */
+export function sampleChapterPose(
+  index: number,
+  outPosition: THREE.Vector3,
+  outTarget: THREE.Vector3,
+  chapters: readonly CameraChapter[] = CAMERA_CHAPTERS
+): void {
+  const clamped = Math.min(Math.max(index, 0), chapters.length - 1);
+  const chapter = chapters[clamped];
+  outPosition.set(...chapter.position);
+  outTarget.set(...chapter.target);
+}


### PR DESCRIPTION
Stacked PR **2 of 7**. Base: `feat/scroll-integrity` (#88).

The scene group was rotated by `scrollProgress * PI`, which displaced every authored object placement in world space to fake camera travel, and left the page feeling stuck once that arc ran out.

Drive a Catmull-Rom camera spline from scroll instead. Objects stay exactly where they were authored — this satisfies the "preserve the 3D placements" constraint more strictly than the previous behaviour did, since a world spin moves everything in world space. The viewpoint parks on its closing shot past `CAMERA_ARC_END` (0.62) so the DOM layer keeps scrolling underneath with no wall. Pointer parallax moves to the camera for the same reason.

Five chapters: high isometric hero, eye-level CRT framing, diagonal terrain pull-back, low three-quarter on the prism, horizon panorama.

Under `prefers-reduced-motion` the arc cuts discretely between authored shots with no scrubbing and no pointer drift.

Spline maths lives in `lib/camera/cinematicSpline.ts` as pure functions so the chapters and clamping are asserted directly; the render loop writes through module-scope scratch vectors and allocates nothing.

### Verification
All four local gates green. Walked all five chapters in the browser; Contact reachable at the end of the track.
