### PR TITLE
feat(ui): occlude the 3D world behind reading-dense sections

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import './components/Arrow.css';
 /** Page-count churn below this is ignored, so card expansions don't retrigger layout. */
 const SCROLL_PAGE_EPSILON = 0.05;
 
+
 function App() {
   const [isLoading, setIsLoading] = useState(true);
   const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(null);

--- a/src/components/sections/About/About.tsx
+++ b/src/components/sections/About/About.tsx
@@ -4,6 +4,7 @@ import { Card } from '../../ui/Card';
 import { CardTitle, CardText, TagsGrid, Tag } from '../../ui/Card';
 import styles from './About.module.css';
 import { cvData } from '../../../data/cv';
+import { FocusScrim } from '../../ui/FocusScrim';
 
 const containerVariants = {
   hidden: { opacity: 0 },
@@ -53,6 +54,7 @@ export function About() {
 
   return (
     <section ref={containerRef} className={styles.about} id="about">
+      <FocusScrim />
       <div className={styles.content}>
         {/* Section Header: Left-Aligned Directly Below the Indicator Arrow */}
         <motion.div 

--- a/src/components/sections/Contact/Contact.tsx
+++ b/src/components/sections/Contact/Contact.tsx
@@ -7,6 +7,7 @@ import { ContactForm } from './ContactForm';
 import { soundFx } from '@/lib/gateways/soundFx';
 import styles from './Contact.module.css';
 import { cvData } from '../../../data/cv';
+import { FocusScrim } from '../../ui/FocusScrim';
 
 export function Contact() {
   const containerRef = useRef<HTMLElement>(null);
@@ -17,6 +18,7 @@ export function Contact() {
 
   return (
     <section ref={containerRef} className={styles.contact} id="contact">
+      <FocusScrim />
       <div className={styles.content}>
         <div className={styles.header}>
           <KineticHeading 

--- a/src/components/sections/Projects/Projects.sectionFocus.test.tsx
+++ b/src/components/sections/Projects/Projects.sectionFocus.test.tsx
@@ -23,6 +23,11 @@ vi.mock('../../ui/expandable-tabs', () => ({
   ExpandableTabs: () => <div />,
 }));
 
+// Isolated so the only observer under test is the section-tracking one.
+vi.mock('../../ui/FocusScrim', () => ({
+  FocusScrim: () => <div data-testid="focus-scrim" />,
+}));
+
 vi.mock('../../ui/KineticText', () => ({
   KineticHeading: ({ text }: { text: string }) => <h2>{text}</h2>,
 }));

--- a/src/components/sections/Projects/Projects.tsx
+++ b/src/components/sections/Projects/Projects.tsx
@@ -6,6 +6,7 @@ import { projectsData } from '../../../data/projects';
 import { ExpandableTabs } from '../../ui/expandable-tabs';
 import { FocusRail, type FocusRailItem } from '../../ui/focus-rail';
 import { KineticHeading } from '../../ui/KineticText';
+import { FocusScrim } from '../../ui/FocusScrim';
 
 const categories = [
   { title: 'All', icon: Grid3x3 },
@@ -96,6 +97,7 @@ export function Projects({ theme }: { theme?: string }) {
 
   return (
     <section ref={containerRef} className={styles.projects} id="projects">
+      <FocusScrim />
       <motion.div
         className={styles.content}
         style={{

--- a/src/components/sections/Skills/Skills.tsx
+++ b/src/components/sections/Skills/Skills.tsx
@@ -4,6 +4,7 @@ import { KineticHeading, DancingCharText } from '../../ui/KineticText';
 import styles from './Skills.module.css';
 
 import { cvData } from '../../../data/cv';
+import { FocusScrim } from '../../ui/FocusScrim';
 
 const skillCategories = cvData.skills;
 
@@ -18,6 +19,7 @@ export function Skills() {
 
   return (
     <section ref={containerRef} className={styles.skills} id="skills">
+      <FocusScrim />
       <motion.div 
         className={styles.content}
         style={{ y }}

--- a/src/components/ui/FocusScrim/FocusScrim.module.css
+++ b/src/components/ui/FocusScrim/FocusScrim.module.css
@@ -1,0 +1,68 @@
+/*
+ * Scoped to the section that renders it, rather than pinned to the viewport.
+ *
+ * The html layer lives inside a transformed ancestor, which makes
+ * position:fixed resolve against that ancestor instead of the viewport, and
+ * leaves position:sticky with no scrollport to stick to. An absolutely
+ * positioned child of the section has neither problem and covers exactly the
+ * extent that needs the contrast.
+ *
+ * z-index -1 keeps it behind the section's own copy while staying inside the
+ * section's stacking context, so it still occludes the canvas underneath.
+ */
+.scrim {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  will-change: opacity;
+
+  background: linear-gradient(
+    to bottom,
+    rgba(0, 18, 20, 0.86) 0%,
+    rgba(0, 12, 16, 0.94) 50%,
+    rgba(0, 18, 20, 0.86) 100%
+  );
+
+  /* Feathered edges, so the scrim reveals the world instead of ending on a seam. */
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    transparent 0,
+    #000 12vh,
+    #000 calc(100% - 12vh),
+    transparent 100%
+  );
+  mask-image: linear-gradient(
+    to bottom,
+    transparent 0,
+    #000 12vh,
+    #000 calc(100% - 12vh),
+    transparent 100%
+  );
+
+  transition: opacity 620ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@supports (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px)) {
+  .scrim {
+    /* Without support the gradient alone still carries the contrast. */
+    -webkit-backdrop-filter: blur(9px) saturate(115%);
+    backdrop-filter: blur(9px) saturate(115%);
+  }
+}
+
+:global([data-theme='light']) .scrim {
+  background: linear-gradient(
+    to bottom,
+    rgba(244, 247, 255, 0.88) 0%,
+    rgba(232, 238, 250, 0.95) 50%,
+    rgba(244, 247, 255, 0.88) 100%
+  );
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scrim {
+    /* The scrim is a legibility aid, not decoration: keep it, drop the fade. */
+    transition: none;
+  }
+}

--- a/src/components/ui/FocusScrim/FocusScrim.test.tsx
+++ b/src/components/ui/FocusScrim/FocusScrim.test.tsx
@@ -1,0 +1,159 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { render, screen, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { FocusScrim } from './FocusScrim';
+import { FULL_FOCUS_COVERAGE } from './focusStrength';
+
+type ObserverCallback = (entries: any[]) => void;
+
+let capturedCallback: ObserverCallback | null = null;
+let observedTargets: Element[] = [];
+let disconnectSpy: ReturnType<typeof vi.fn>;
+const originalObserver = globalThis.IntersectionObserver;
+
+class FakeIntersectionObserver {
+  constructor(callback: ObserverCallback) {
+    capturedCallback = callback;
+  }
+  observe(el: Element) {
+    observedTargets.push(el);
+  }
+  unobserve() {}
+  disconnect() {
+    disconnectSpy();
+  }
+  takeRecords() {
+    return [];
+  }
+}
+
+const VIEWPORT = 800;
+
+const entry = (visibleHeight: number, isIntersecting = visibleHeight > 0) => ({
+  isIntersecting,
+  intersectionRect: { height: visibleHeight },
+  rootBounds: { height: VIEWPORT },
+});
+
+/** Renders the scrim inside a section, which is how sections use it. */
+const renderInSection = (props = {}) =>
+  render(
+    <section id="skills">
+      <FocusScrim {...props} />
+    </section>
+  );
+
+const scrim = () => screen.getByTestId('focus-scrim');
+const strengthOf = () => Number(scrim().getAttribute('data-focus-strength'));
+const opacityOf = () => Number(scrim().style.opacity);
+
+describe('FocusScrim', () => {
+  beforeEach(() => {
+    capturedCallback = null;
+    observedTargets = [];
+    disconnectSpy = vi.fn();
+    (globalThis as any).IntersectionObserver = FakeIntersectionObserver;
+  });
+
+  afterEach(() => {
+    (globalThis as any).IntersectionObserver = originalObserver;
+  });
+
+  it('is fully transparent before its section is on screen', () => {
+    renderInSection();
+    expect(opacityOf()).toBe(0);
+  });
+
+  it('observes the section it was rendered into, not itself', () => {
+    renderInSection();
+    expect(observedTargets).toHaveLength(1);
+    expect((observedTargets[0] as HTMLElement).id).toBe('skills');
+  });
+
+  it('is hidden from assistive technology', () => {
+    renderInSection();
+    expect(scrim()).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('fades up as the section takes over the viewport', () => {
+    renderInSection();
+
+    act(() => {
+      capturedCallback?.([entry(VIEWPORT * FULL_FOCUS_COVERAGE * 0.5)]);
+    });
+
+    expect(strengthOf()).toBeCloseTo(0.5, 3);
+  });
+
+  it('reaches peak opacity once the section dominates the viewport', () => {
+    renderInSection({ maxOpacity: 0.9 });
+
+    act(() => {
+      capturedCallback?.([entry(VIEWPORT)]);
+    });
+
+    expect(strengthOf()).toBe(1);
+    expect(opacityOf()).toBeCloseTo(0.9, 5);
+  });
+
+  it('fades back out to reveal the scene when the section leaves', () => {
+    renderInSection();
+
+    act(() => capturedCallback?.([entry(VIEWPORT)]));
+    expect(strengthOf()).toBe(1);
+
+    act(() => capturedCallback?.([entry(0, false)]));
+    expect(strengthOf()).toBe(0);
+  });
+
+  it('treats a non-intersecting entry as fully off screen even if a rect is reported', () => {
+    renderInSection();
+
+    act(() => capturedCallback?.([entry(VIEWPORT, false)]));
+    expect(strengthOf()).toBe(0);
+  });
+
+  it('uses the latest entry when the observer batches several', () => {
+    renderInSection();
+
+    act(() => {
+      capturedCallback?.([entry(0, false), entry(VIEWPORT)]);
+    });
+
+    expect(strengthOf()).toBe(1);
+  });
+
+  it('ignores an empty callback batch', () => {
+    renderInSection();
+    act(() => capturedCallback?.([]));
+    expect(strengthOf()).toBe(0);
+  });
+
+  it('falls back to the window height when rootBounds is null', () => {
+    renderInSection();
+
+    act(() => {
+      capturedCallback?.([
+        {
+          isIntersecting: true,
+          intersectionRect: { height: window.innerHeight },
+          rootBounds: null,
+        },
+      ]);
+    });
+
+    expect(strengthOf()).toBe(1);
+  });
+
+  it('disconnects its observer on unmount', () => {
+    const { unmount } = renderInSection();
+    unmount();
+    expect(disconnectSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders inertly when IntersectionObserver is unavailable', () => {
+    (globalThis as any).IntersectionObserver = undefined;
+    expect(() => renderInSection()).not.toThrow();
+    expect(opacityOf()).toBe(0);
+  });
+});

--- a/src/components/ui/FocusScrim/FocusScrim.tsx
+++ b/src/components/ui/FocusScrim/FocusScrim.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useRef, useState } from 'react';
+import styles from './FocusScrim.module.css';
+import { focusStrength } from './focusStrength';
+
+/**
+ * Occludes the live 3D world behind the section that renders it.
+ *
+ * Long-form copy over moving terrain is unreadable at almost any opacity. The
+ * scrim fades up as its section takes over the viewport and fades back out as
+ * the section leaves, so the world returns between reading passages.
+ *
+ * Render it as a direct child of a positioned section; it measures that parent.
+ */
+
+/** Enough to carry text contrast while the world stays faintly present. */
+const DEFAULT_MAX_OPACITY = 0.92;
+
+/** Coverage steps sampled by the observer. More steps means a smoother ramp. */
+const THRESHOLDS = Array.from({ length: 21 }, (_, i) => i / 20);
+
+export interface FocusScrimProps {
+  /** Peak scrim opacity. */
+  maxOpacity?: number;
+}
+
+export function FocusScrim({ maxOpacity = DEFAULT_MAX_OPACITY }: FocusScrimProps = {}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [strength, setStrength] = useState(0);
+
+  useEffect(() => {
+    const section = ref.current?.parentElement;
+    if (!section || typeof IntersectionObserver === 'undefined') return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[entries.length - 1];
+        if (!entry) return;
+
+        const rootHeight =
+          entry.rootBounds?.height ??
+          (typeof window !== 'undefined' ? window.innerHeight : 0);
+
+        const visibleHeight = entry.isIntersecting
+          ? (entry.intersectionRect?.height ?? 0)
+          : 0;
+
+        setStrength(focusStrength(visibleHeight, rootHeight));
+      },
+      { threshold: THRESHOLDS }
+    );
+
+    observer.observe(section);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div
+      ref={ref}
+      className={styles.scrim}
+      style={{ opacity: strength * maxOpacity }}
+      aria-hidden="true"
+      data-testid="focus-scrim"
+      data-focus-strength={strength.toFixed(3)}
+    />
+  );
+}

--- a/src/components/ui/FocusScrim/focusStrength.test.ts
+++ b/src/components/ui/FocusScrim/focusStrength.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { focusStrength, FULL_FOCUS_COVERAGE } from './focusStrength';
+
+describe('focusStrength', () => {
+  it('is zero when the section is off screen', () => {
+    expect(focusStrength(0, 1000)).toBe(0);
+  });
+
+  it('scales with how much of the viewport the section covers', () => {
+    // Half of full coverage should read as half strength.
+    expect(focusStrength(1000 * FULL_FOCUS_COVERAGE * 0.5, 1000)).toBeCloseTo(0.5, 5);
+  });
+
+  it('reaches full strength at the coverage threshold', () => {
+    expect(focusStrength(1000 * FULL_FOCUS_COVERAGE, 1000)).toBe(1);
+  });
+
+  it('clamps rather than exceeding full strength', () => {
+    expect(focusStrength(1000, 1000)).toBe(1);
+  });
+
+  it('reaches full strength for a section far taller than the viewport', () => {
+    // The whole point of measuring viewport coverage instead of
+    // intersectionRatio: a six-screen section fills the viewport completely
+    // while its own intersection ratio never exceeds ~0.17.
+    const viewport = 800;
+    expect(focusStrength(viewport, viewport)).toBe(1);
+  });
+
+  it('is zero for a degenerate viewport', () => {
+    expect(focusStrength(500, 0)).toBe(0);
+    expect(focusStrength(500, -10)).toBe(0);
+  });
+
+  it('is zero for negative or non-finite coverage', () => {
+    expect(focusStrength(-100, 1000)).toBe(0);
+    expect(focusStrength(Number.NaN, 1000)).toBe(0);
+    expect(focusStrength(100, Number.NaN)).toBe(0);
+  });
+
+  it('treats a zero threshold as always fully focused', () => {
+    expect(focusStrength(1, 1000, 0)).toBe(1);
+  });
+
+  it('honours a custom coverage threshold', () => {
+    expect(focusStrength(250, 1000, 0.25)).toBe(1);
+    expect(focusStrength(125, 1000, 0.25)).toBeCloseTo(0.5, 5);
+  });
+});

--- a/src/components/ui/FocusScrim/focusStrength.ts
+++ b/src/components/ui/FocusScrim/focusStrength.ts
@@ -1,0 +1,28 @@
+/**
+ * Share of the viewport a section must cover before the scrim reaches full
+ * strength. Below this the scene stays legible around the copy.
+ */
+export const FULL_FOCUS_COVERAGE = 0.55;
+
+/**
+ * Maps how much of the *viewport* a section occupies onto scrim strength.
+ *
+ * Deliberately not IntersectionObserver's `intersectionRatio`, which is a
+ * fraction of the observed element: a section six screens tall can never exceed
+ * a ratio of ~0.17 no matter how completely it fills the screen.
+ */
+export function focusStrength(
+  intersectionHeight: number,
+  rootHeight: number,
+  fullCoverage: number = FULL_FOCUS_COVERAGE
+): number {
+  if (!Number.isFinite(intersectionHeight) || intersectionHeight <= 0) return 0;
+  if (!Number.isFinite(rootHeight) || rootHeight <= 0) return 0;
+
+  const coverage = intersectionHeight / rootHeight;
+  if (fullCoverage <= 0) return 1;
+
+  const strength = coverage / fullCoverage;
+  if (strength <= 0) return 0;
+  return strength >= 1 ? 1 : strength;
+}

--- a/src/components/ui/FocusScrim/index.ts
+++ b/src/components/ui/FocusScrim/index.ts
@@ -1,0 +1,3 @@
+export { FocusScrim } from './FocusScrim';
+export type { FocusScrimProps } from './FocusScrim';
+export { focusStrength, FULL_FOCUS_COVERAGE } from './focusStrength';


### PR DESCRIPTION
Stacked PR **3 of 7**. Base: `feat/cinematic-camera`.

Long-form copy sat directly on the live terrain. Verified in the browser: the Skills tag grid and the About statement columns were effectively **unreadable** wherever the island passed behind them.

Adds a scrim that fades up in proportion to how much of the viewport its section occupies, and fades back out to reveal the scene between reading passages.

Two design constraints drove the implementation, both confirmed broken in the browser before settling on the current approach:

- **Not `position: fixed`** — the html layer sits inside a transformed ancestor, which makes fixed resolve against that ancestor instead of the viewport.
- **Not `position: sticky`** — there is no scrollport for it to stick to here; it measured at `y = -4311` in practice.

So the scrim is scoped to its section as an absolutely positioned child.

Strength comes from **viewport coverage**, not `IntersectionObserver`'s `intersectionRatio`. That ratio is a fraction of the observed element: About is nearly four screens tall, so its ratio never exceeds ~0.25 no matter how completely it fills the screen.

Edges are feathered with a mask so the scrim resolves into the world instead of ending on a seam. Under `prefers-reduced-motion` the fade is dropped but the contrast is kept — it is a legibility aid, not decoration.

### Verification
All four local gates green. Browser: Skills, About and Contact go from unreadable to crisp, in both light and dark themes.
