### PR TITLE
feat(3d): add a drifting atmospheric mote layer

### DIFF
--- a/src/components/3d/AtmosphericDrift.test.tsx
+++ b/src/components/3d/AtmosphericDrift.test.tsx
@@ -1,0 +1,81 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AtmosphericDrift } from './AtmosphericDrift';
+
+let frameCallback: ((state: any) => void) | null = null;
+
+vi.mock('@react-three/fiber', () => ({
+  useFrame: (callback: (state: any) => void) => {
+    frameCallback = callback;
+  },
+}));
+
+const reducedMotion = vi.fn(() => false);
+vi.mock('@/lib/gateways/animationGateway', () => ({
+  getPrefersReducedMotion: () => reducedMotion(),
+}));
+
+const writeSpy = vi.fn();
+vi.mock('@/lib/atmosphere/writeDriftInstances', () => ({
+  writeDriftInstances: (...args: unknown[]) => writeSpy(...args),
+}));
+
+const frame = (elapsed = 1) =>
+  frameCallback?.({ clock: { getElapsedTime: () => elapsed } });
+
+describe('AtmosphericDrift', () => {
+  beforeEach(() => {
+    frameCallback = null;
+    writeSpy.mockClear();
+    reducedMotion.mockReturnValue(false);
+  });
+
+  it('renders a single instanced draw call sized to the budget', () => {
+    const { container } = render(<AtmosphericDrift count={120} color="#00ff9d" />);
+    // One instanced mesh, not one node per mote.
+    expect(container.querySelectorAll('instancedmesh')).toHaveLength(1);
+    expect(container.querySelectorAll('octahedrongeometry')).toHaveLength(1);
+  });
+
+  it('renders nothing when the budget is zero', () => {
+    const { container } = render(<AtmosphericDrift count={0} color="#00ff9d" />);
+    expect(container.querySelector('instancedmesh')).toBeNull();
+  });
+
+  it('lays the field out once on mount, before any frame runs', () => {
+    render(<AtmosphericDrift count={40} color="#00ff9d" />);
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    expect(writeSpy.mock.calls[0][3]).toBe(0);
+  });
+
+  it('advances the field with the clock on each frame', () => {
+    render(<AtmosphericDrift count={40} color="#00ff9d" />);
+    writeSpy.mockClear();
+
+    frame(2.5);
+
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    expect(writeSpy.mock.calls[0][3]).toBe(2.5);
+  });
+
+  it('holds the field still under reduced motion', () => {
+    reducedMotion.mockReturnValue(true);
+    render(<AtmosphericDrift count={40} color="#00ff9d" />);
+    writeSpy.mockClear();
+
+    frame(4);
+
+    // The mount-time layout still stands, so the field is visible but static.
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+
+  it('does no per-frame work when the budget is zero', () => {
+    render(<AtmosphericDrift count={0} color="#00ff9d" />);
+    writeSpy.mockClear();
+
+    frame(3);
+
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/3d/AtmosphericDrift.tsx
+++ b/src/components/3d/AtmosphericDrift.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { DEFAULT_DRIFT_BOUNDS, createDriftSeeds, type DriftBounds } from '@/lib/atmosphere/drift';
+import { writeDriftInstances } from '@/lib/atmosphere/writeDriftInstances';
+import { getPrefersReducedMotion } from '@/lib/gateways/animationGateway';
+
+/**
+ * Slow motes drifting through the island's air, on a single instanced draw
+ * call. Purely atmospheric: it adds no geometry to the scene's authored
+ * composition and casts nothing.
+ *
+ * The geometry and material are declared as children, so the reconciler owns
+ * their lifetime and disposes them on unmount. Only imperatively constructed
+ * resources -- the cloned terrain in BackgroundScene, for instance -- need a
+ * disposal pass of their own.
+ */
+
+/** Motes are small enough to read as airborne dust rather than as objects. */
+const MOTE_SIZE = 0.045;
+
+export interface AtmosphericDriftProps {
+  /** Instance count, normally taken from the GPU tier budget. */
+  count: number;
+  color: string;
+  bounds?: DriftBounds;
+  opacity?: number;
+}
+
+export function AtmosphericDrift({
+  count,
+  color,
+  bounds = DEFAULT_DRIFT_BOUNDS,
+  opacity = 0.55,
+}: AtmosphericDriftProps) {
+  const meshRef = useRef<THREE.InstancedMesh>(null);
+  const seeds = useMemo(() => createDriftSeeds(count, bounds), [count, bounds]);
+
+  // Lay the field out once, so a reduced-motion visitor still sees it and the
+  // first animated frame does not pop in from the origin.
+  useEffect(() => {
+    const mesh = meshRef.current;
+    if (!mesh) return;
+    writeDriftInstances(mesh, seeds, count, 0, bounds);
+  }, [seeds, count, bounds]);
+
+  useFrame((state) => {
+    const mesh = meshRef.current;
+    if (!mesh || count <= 0) return;
+    if (getPrefersReducedMotion()) return;
+
+    writeDriftInstances(mesh, seeds, count, state.clock.getElapsedTime(), bounds);
+  });
+
+  if (count <= 0) return null;
+
+  return (
+    <instancedMesh
+      ref={meshRef}
+      args={[undefined, undefined, count]}
+      frustumCulled={false}
+    >
+      <octahedronGeometry args={[MOTE_SIZE, 0]} />
+      <meshBasicMaterial
+        color={color}
+        transparent
+        opacity={opacity}
+        depthWrite={false}
+        blending={THREE.AdditiveBlending}
+      />
+    </instancedMesh>
+  );
+}

--- a/src/components/BackgroundScene.test.tsx
+++ b/src/components/BackgroundScene.test.tsx
@@ -66,6 +66,9 @@ vi.mock('./Ocean', () => ({ Ocean: () => null }));
 vi.mock('./ocean/ShorelineBreak', () => ({ ShorelineBreak: () => null }));
 vi.mock('./TVModel', () => ({ TVModel: () => null }));
 vi.mock('./MeModel', () => ({ MeModel: () => null }));
+// Covered by its own suite; the reconciler is faked here, so its instanced mesh
+// would resolve to a DOM node rather than a THREE.InstancedMesh.
+vi.mock('./3d/AtmosphericDrift', () => ({ AtmosphericDrift: () => null }));
 
 describe('BackgroundScene', () => {
   beforeEach(() => {

--- a/src/components/BackgroundScene.tsx
+++ b/src/components/BackgroundScene.tsx
@@ -14,12 +14,16 @@ import { TVModel } from './TVModel';
 import { Ocean } from './Ocean';
 import { ShorelineBreak } from './ocean/ShorelineBreak';
 import { CinematicCameraController } from './3d/CinematicCameraController';
+import { AtmosphericDrift } from './3d/AtmosphericDrift';
 import { getPrefersReducedMotion } from '@/lib/gateways/animationGateway';
 
 const TERRAIN_URL = '/models/terrain-mobile.glb';
 
 /** Used when the caller has no GPU-tier reading yet. */
 const DEFAULT_PARTICLE_COUNT = 800;
+
+/** Share of the particle budget spent on animated motes rather than stars. */
+const DRIFT_BUDGET_SHARE = 0.3;
 
 useGLTF.preload('/models/terrain-mobile.glb');
 
@@ -152,6 +156,9 @@ interface BackgroundSceneProps {
 }
 
 export function BackgroundScene({ theme, particleCount = DEFAULT_PARTICLE_COUNT }: BackgroundSceneProps) {
+  // A fraction of the starfield budget: motes are animated every frame, so they
+  // cost far more per instance than the static point cloud.
+  const driftCount = Math.max(Math.round(particleCount * DRIFT_BUDGET_SHARE), 0);
   const prismRef = useRef<THREE.Group>(null);
 
   const isLight = theme === 'light';
@@ -271,8 +278,15 @@ export function BackgroundScene({ theme, particleCount = DEFAULT_PARTICLE_COUNT 
           />
         </group>
 
-        {/* Ambient Particles */}
+        {/* Distant starfield */}
         <Particles color={palette.highlight} count={particleCount} />
+
+        {/* Motes drifting through the island's air */}
+        <AtmosphericDrift
+          count={driftCount}
+          color={palette.highlight}
+          opacity={isLight ? 0.35 : 0.55}
+        />
 
         <Suspense fallback={null}>
           {/* Placed next to the prism [12, 2, -15] */}

--- a/src/lib/atmosphere/drift.test.ts
+++ b/src/lib/atmosphere/drift.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SEED_STRIDE,
+  SeedOffset,
+  DEFAULT_DRIFT_BOUNDS,
+  createRandom,
+  createDriftSeeds,
+  driftHeight,
+  driftSwayX,
+  driftSwayZ,
+  driftSpin,
+} from './drift';
+
+describe('createRandom', () => {
+  it('is deterministic for a given seed', () => {
+    const a = createRandom(42);
+    const b = createRandom(42);
+    expect([a(), a(), a()]).toEqual([b(), b(), b()]);
+  });
+
+  it('produces different streams for different seeds', () => {
+    expect(createRandom(1)()).not.toBe(createRandom(2)());
+  });
+
+  it('stays within the unit interval', () => {
+    const random = createRandom(7);
+    for (let i = 0; i < 500; i++) {
+      const value = random();
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThan(1);
+    }
+  });
+});
+
+describe('createDriftSeeds', () => {
+  const count = 64;
+  const seeds = createDriftSeeds(count);
+
+  it('packs one stride per instance', () => {
+    expect(seeds).toHaveLength(count * SEED_STRIDE);
+  });
+
+  it('produces the same field on every load', () => {
+    // The composition is art-directed, not random per visit.
+    expect(Array.from(createDriftSeeds(8))).toEqual(Array.from(createDriftSeeds(8)));
+  });
+
+  it('places every instance inside the field bounds', () => {
+    const { radius, floor, ceiling } = DEFAULT_DRIFT_BOUNDS;
+    for (let i = 0; i < count; i++) {
+      const base = i * SEED_STRIDE;
+      expect(Math.abs(seeds[base + SeedOffset.OriginX])).toBeLessThanOrEqual(radius);
+      expect(Math.abs(seeds[base + SeedOffset.OriginZ])).toBeLessThanOrEqual(radius);
+      expect(seeds[base + SeedOffset.OriginY]).toBeGreaterThanOrEqual(floor);
+      expect(seeds[base + SeedOffset.OriginY]).toBeLessThanOrEqual(ceiling);
+    }
+  });
+
+  it('gives every instance a downward fall speed', () => {
+    for (let i = 0; i < count; i++) {
+      expect(seeds[i * SEED_STRIDE + SeedOffset.FallSpeed]).toBeGreaterThan(0);
+    }
+  });
+
+  it('spreads sway phases so instances do not move in lockstep', () => {
+    const phases = new Set<number>();
+    for (let i = 0; i < count; i++) {
+      phases.add(seeds[i * SEED_STRIDE + SeedOffset.Phase]);
+    }
+    expect(phases.size).toBeGreaterThan(count * 0.9);
+  });
+
+  it('returns an empty buffer for a non-positive or non-finite count', () => {
+    expect(createDriftSeeds(0)).toHaveLength(0);
+    expect(createDriftSeeds(-5)).toHaveLength(0);
+    expect(createDriftSeeds(Number.NaN)).toHaveLength(0);
+  });
+});
+
+describe('driftHeight', () => {
+  const seeds = createDriftSeeds(32);
+
+  it('starts each instance at its seeded height', () => {
+    expect(driftHeight(seeds, 3, 0)).toBeCloseTo(seeds[3 * SEED_STRIDE + SeedOffset.OriginY], 5);
+  });
+
+  it('falls over time', () => {
+    expect(driftHeight(seeds, 3, 1)).toBeLessThan(driftHeight(seeds, 3, 0));
+  });
+
+  it('stays inside the field for very large elapsed times', () => {
+    const { floor, ceiling } = DEFAULT_DRIFT_BOUNDS;
+    for (const time of [0, 12, 500, 100000]) {
+      for (let i = 0; i < 32; i++) {
+        const y = driftHeight(seeds, i, time);
+        expect(y).toBeGreaterThanOrEqual(floor);
+        expect(y).toBeLessThanOrEqual(ceiling);
+      }
+    }
+  });
+
+  it('wraps back to the top rather than sinking below the floor', () => {
+    const { floor, ceiling } = DEFAULT_DRIFT_BOUNDS;
+    const span = ceiling - floor;
+    const fallSpeed = seeds[SeedOffset.FallSpeed];
+    // Exactly one full traversal returns to the starting height.
+    expect(driftHeight(seeds, 0, span / fallSpeed)).toBeCloseTo(driftHeight(seeds, 0, 0), 3);
+  });
+
+  it('collapses to the floor for a degenerate field', () => {
+    const flat = { radius: 10, floor: 2, ceiling: 2 };
+    expect(driftHeight(seeds, 0, 5, flat)).toBe(2);
+  });
+});
+
+describe('drift sway and spin', () => {
+  const seeds = createDriftSeeds(16);
+
+  it('starts sway from the seeded origin at the phase offset', () => {
+    const base = 5 * SEED_STRIDE;
+    const expected =
+      seeds[base + SeedOffset.OriginX] +
+      Math.sin(seeds[base + SeedOffset.Phase]) * seeds[base + SeedOffset.Amplitude];
+    expect(driftSwayX(seeds, 5, 0)).toBeCloseTo(expected, 5);
+  });
+
+  it('keeps sway bounded by the seeded amplitude', () => {
+    for (let i = 0; i < 16; i++) {
+      const base = i * SEED_STRIDE;
+      const amplitude = seeds[base + SeedOffset.Amplitude];
+      for (let t = 0; t < 40; t += 0.37) {
+        expect(Math.abs(driftSwayX(seeds, i, t) - seeds[base + SeedOffset.OriginX]))
+          .toBeLessThanOrEqual(amplitude + 1e-6);
+        expect(Math.abs(driftSwayZ(seeds, i, t) - seeds[base + SeedOffset.OriginZ]))
+          .toBeLessThanOrEqual(amplitude + 1e-6);
+      }
+    }
+  });
+
+  it('sways x and z on different periods so motion does not read as a circle', () => {
+    const base = 2 * SEED_STRIDE;
+    const dx = driftSwayX(seeds, 2, 3) - seeds[base + SeedOffset.OriginX];
+    const dz = driftSwayZ(seeds, 2, 3) - seeds[base + SeedOffset.OriginZ];
+    expect(Math.abs(Math.abs(dx) - Math.abs(dz))).toBeGreaterThan(1e-4);
+  });
+
+  it('tumbles continuously from the phase offset', () => {
+    expect(driftSpin(seeds, 4, 0)).toBeCloseTo(seeds[4 * SEED_STRIDE + SeedOffset.Phase], 5);
+    expect(driftSpin(seeds, 4, 10)).not.toBeCloseTo(driftSpin(seeds, 4, 0), 3);
+  });
+});

--- a/src/lib/atmosphere/drift.ts
+++ b/src/lib/atmosphere/drift.ts
@@ -1,0 +1,129 @@
+/**
+ * Motion model for the drifting atmospheric motes.
+ *
+ * Kept as plain math, separate from the R3F component, so the trajectories can
+ * be asserted directly and so the render loop can stay allocation-free.
+ */
+
+/** Per-instance values packed into one flat array. */
+export const SEED_STRIDE = 7;
+
+export const enum SeedOffset {
+  OriginX = 0,
+  OriginY = 1,
+  OriginZ = 2,
+  /** Phase offset, so instances do not sway in lockstep. */
+  Phase = 3,
+  /** Horizontal sway amplitude in world units. */
+  Amplitude = 4,
+  /** Fall speed in world units per second. */
+  FallSpeed = 5,
+  /** Tumble rate in radians per second. */
+  SpinSpeed = 6,
+}
+
+export interface DriftBounds {
+  /** Half-width of the field on x and z. */
+  readonly radius: number;
+  /** Lowest point of the field; instances wrap back to the top from here. */
+  readonly floor: number;
+  /** Highest point of the field. */
+  readonly ceiling: number;
+}
+
+export const DEFAULT_DRIFT_BOUNDS: DriftBounds = {
+  radius: 26,
+  floor: -4,
+  ceiling: 22,
+};
+
+/**
+ * Deterministic PRNG (mulberry32). The field must look identical on every load
+ * so the composition is art-directed rather than random per visit.
+ */
+export function createRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function createDriftSeeds(
+  count: number,
+  bounds: DriftBounds = DEFAULT_DRIFT_BOUNDS,
+  seed = 0x5eed
+): Float32Array {
+  const safeCount = Number.isFinite(count) && count > 0 ? Math.floor(count) : 0;
+  const seeds = new Float32Array(safeCount * SEED_STRIDE);
+  const random = createRandom(seed);
+  const span = bounds.ceiling - bounds.floor;
+
+  for (let i = 0; i < safeCount; i++) {
+    const base = i * SEED_STRIDE;
+    seeds[base + SeedOffset.OriginX] = (random() - 0.5) * 2 * bounds.radius;
+    seeds[base + SeedOffset.OriginY] = bounds.floor + random() * span;
+    seeds[base + SeedOffset.OriginZ] = (random() - 0.5) * 2 * bounds.radius;
+    seeds[base + SeedOffset.Phase] = random() * Math.PI * 2;
+    seeds[base + SeedOffset.Amplitude] = 0.4 + random() * 1.6;
+    seeds[base + SeedOffset.FallSpeed] = 0.25 + random() * 0.55;
+    seeds[base + SeedOffset.SpinSpeed] = (random() - 0.5) * 1.2;
+  }
+
+  return seeds;
+}
+
+/**
+ * Height of instance `index` at `time`, wrapped into the field.
+ *
+ * Uses a positive modulo so the field is continuous rather than snapping when
+ * the elapsed clock is large.
+ */
+export function driftHeight(
+  seeds: Float32Array,
+  index: number,
+  time: number,
+  bounds: DriftBounds = DEFAULT_DRIFT_BOUNDS
+): number {
+  const base = index * SEED_STRIDE;
+  const span = bounds.ceiling - bounds.floor;
+  if (span <= 0) return bounds.floor;
+
+  const fallen =
+    seeds[base + SeedOffset.OriginY] - seeds[base + SeedOffset.FallSpeed] * time;
+
+  const wrapped = (((fallen - bounds.floor) % span) + span) % span;
+  return bounds.floor + wrapped;
+}
+
+/** Horizontal sway of instance `index` at `time`, on the x axis. */
+export function driftSwayX(seeds: Float32Array, index: number, time: number): number {
+  const base = index * SEED_STRIDE;
+  return (
+    seeds[base + SeedOffset.OriginX] +
+    Math.sin(time * 0.6 + seeds[base + SeedOffset.Phase]) *
+      seeds[base + SeedOffset.Amplitude]
+  );
+}
+
+/** Horizontal sway of instance `index` at `time`, on the z axis. */
+export function driftSwayZ(seeds: Float32Array, index: number, time: number): number {
+  const base = index * SEED_STRIDE;
+  return (
+    seeds[base + SeedOffset.OriginZ] +
+    Math.cos(time * 0.43 + seeds[base + SeedOffset.Phase]) *
+      seeds[base + SeedOffset.Amplitude] *
+      0.6
+  );
+}
+
+/** Tumble angle of instance `index` at `time`. */
+export function driftSpin(seeds: Float32Array, index: number, time: number): number {
+  const base = index * SEED_STRIDE;
+  return (
+    seeds[base + SeedOffset.Phase] + seeds[base + SeedOffset.SpinSpeed] * time
+  );
+}

--- a/src/lib/atmosphere/writeDriftInstances.test.ts
+++ b/src/lib/atmosphere/writeDriftInstances.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import { writeDriftInstances } from './writeDriftInstances';
+import {
+  DEFAULT_DRIFT_BOUNDS,
+  createDriftSeeds,
+  driftHeight,
+  driftSwayX,
+  driftSwayZ,
+} from './drift';
+
+const COUNT = 24;
+
+const makeMesh = (count = COUNT) =>
+  new THREE.InstancedMesh(
+    new THREE.OctahedronGeometry(0.05, 0),
+    new THREE.MeshBasicMaterial(),
+    count
+  );
+
+const positionOf = (mesh: THREE.InstancedMesh, index: number) => {
+  const matrix = new THREE.Matrix4();
+  mesh.getMatrixAt(index, matrix);
+  return new THREE.Vector3().setFromMatrixPosition(matrix);
+};
+
+describe('writeDriftInstances', () => {
+  it('places every instance at its modelled position', () => {
+    const mesh = makeMesh();
+    const seeds = createDriftSeeds(COUNT);
+
+    writeDriftInstances(mesh, seeds, COUNT, 3.5);
+
+    for (let i = 0; i < COUNT; i++) {
+      const position = positionOf(mesh, i);
+      expect(position.x).toBeCloseTo(driftSwayX(seeds, i, 3.5), 4);
+      expect(position.y).toBeCloseTo(driftHeight(seeds, i, 3.5), 4);
+      expect(position.z).toBeCloseTo(driftSwayZ(seeds, i, 3.5), 4);
+    }
+  });
+
+  it('flags the instance buffer for upload', () => {
+    const mesh = makeMesh();
+    // `needsUpdate` is a write-only accessor in three; it bumps `version`.
+    const before = mesh.instanceMatrix.version;
+
+    writeDriftInstances(mesh, createDriftSeeds(COUNT), COUNT, 0);
+
+    expect(mesh.instanceMatrix.version).toBeGreaterThan(before);
+  });
+
+  it('moves the field between frames', () => {
+    const mesh = makeMesh();
+    const seeds = createDriftSeeds(COUNT);
+
+    writeDriftInstances(mesh, seeds, COUNT, 0);
+    const before = positionOf(mesh, 5);
+
+    writeDriftInstances(mesh, seeds, COUNT, 1.2);
+    const after = positionOf(mesh, 5);
+
+    expect(before.distanceTo(after)).toBeGreaterThan(0);
+  });
+
+  it('keeps every instance inside the field over a long run', () => {
+    const mesh = makeMesh();
+    const seeds = createDriftSeeds(COUNT);
+    const { radius, floor, ceiling } = DEFAULT_DRIFT_BOUNDS;
+
+    for (const time of [0, 30, 600, 100000]) {
+      writeDriftInstances(mesh, seeds, COUNT, time);
+      for (let i = 0; i < COUNT; i++) {
+        const position = positionOf(mesh, i);
+        expect(position.y).toBeGreaterThanOrEqual(floor - 1e-4);
+        expect(position.y).toBeLessThanOrEqual(ceiling + 1e-4);
+        // Origin plus the maximum seeded sway amplitude.
+        expect(Math.abs(position.x)).toBeLessThanOrEqual(radius + 2.1);
+        expect(Math.abs(position.z)).toBeLessThanOrEqual(radius + 2.1);
+      }
+    }
+  });
+
+  it('honours custom bounds', () => {
+    const mesh = makeMesh();
+    const bounds = { radius: 4, floor: 0, ceiling: 3 };
+    const seeds = createDriftSeeds(COUNT, bounds);
+
+    writeDriftInstances(mesh, seeds, COUNT, 17, bounds);
+
+    for (let i = 0; i < COUNT; i++) {
+      const y = positionOf(mesh, i).y;
+      expect(y).toBeGreaterThanOrEqual(-1e-4);
+      expect(y).toBeLessThanOrEqual(3 + 1e-4);
+    }
+  });
+
+  it('writes nothing for a zero count', () => {
+    const mesh = makeMesh(1);
+    const identity = new THREE.Matrix4();
+    mesh.setMatrixAt(0, identity);
+
+    writeDriftInstances(mesh, createDriftSeeds(0), 0, 5);
+
+    expect(positionOf(mesh, 0).length()).toBe(0);
+  });
+
+  it('reuses one scratch transform rather than allocating per instance', () => {
+    // Two passes over a large field must not depend on allocation order.
+    const mesh = makeMesh(400);
+    const seeds = createDriftSeeds(400);
+
+    writeDriftInstances(mesh, seeds, 400, 2);
+    const first = positionOf(mesh, 399).clone();
+
+    writeDriftInstances(mesh, seeds, 400, 2);
+    expect(positionOf(mesh, 399).distanceTo(first)).toBe(0);
+  });
+});

--- a/src/lib/atmosphere/writeDriftInstances.ts
+++ b/src/lib/atmosphere/writeDriftInstances.ts
@@ -1,0 +1,39 @@
+import * as THREE from 'three';
+import {
+  DEFAULT_DRIFT_BOUNDS,
+  driftHeight,
+  driftSpin,
+  driftSwayX,
+  driftSwayZ,
+  type DriftBounds,
+} from './drift';
+
+/**
+ * Module-scope scratch. Allocating per instance per frame would churn the GC
+ * hundreds of times a frame at production instance counts.
+ */
+const scratchObject = new THREE.Object3D();
+
+/** Writes every mote's transform for `time` into the instanced mesh. */
+export function writeDriftInstances(
+  mesh: THREE.InstancedMesh,
+  seeds: Float32Array,
+  count: number,
+  time: number,
+  bounds: DriftBounds = DEFAULT_DRIFT_BOUNDS
+): void {
+  for (let i = 0; i < count; i++) {
+    scratchObject.position.set(
+      driftSwayX(seeds, i, time),
+      driftHeight(seeds, i, time, bounds),
+      driftSwayZ(seeds, i, time)
+    );
+
+    const spin = driftSpin(seeds, i, time);
+    scratchObject.rotation.set(spin, spin * 0.7, 0);
+    scratchObject.updateMatrix();
+    mesh.setMatrixAt(i, scratchObject.matrix);
+  }
+
+  mesh.instanceMatrix.needsUpdate = true;
+}


### PR DESCRIPTION
Stacked PR **4 of 7**. Base: `feat/focus-scrims`.

Adds slow airborne motes on a single instanced draw call, sized from the same GPU-tier budget as the starfield and taking a 30% share of it, since animated instances cost far more per unit than a static point cloud. Object placements in the scene are untouched.

- Motion model is plain maths in `lib/atmosphere`, so trajectories are asserted directly rather than inferred from a render.
- The frame loop writes through one module-scope scratch transform instead of allocating per instance.
- Heights wrap with a positive modulo, so the field stays continuous at large elapsed times rather than snapping.
- Seeding is deterministic — the field is art-directed and should not reshuffle on every visit.
- Under `prefers-reduced-motion` the field is laid out once and then held still: present, but static.
- Geometry and material are declared as children, so the reconciler owns their disposal. Only imperatively constructed resources — the cloned terrain in `BackgroundScene` — need a pass of their own.

### Verification
All four local gates green. Motes confirmed drifting in the browser.
