### PR TITLE
fix(nav): drop unreachable window-scroll logic

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -259,8 +259,13 @@
   transform: rotate(12deg);
 }
 
+/*
+ * A breath between the project rail and the contact form, where both focus
+ * scrims sit at zero and the 3D world is fully revealed. One screen was two
+ * screens of nothing; just over half gives the beat without the void.
+ */
 .spacer {
-  height: 120vh;
+  height: 60vh;
   width: 100%;
   position: relative;
   z-index: 1;

--- a/src/components/Navigation.branch.test.tsx
+++ b/src/components/Navigation.branch.test.tsx
@@ -63,46 +63,19 @@ describe('Navigation Branch Coverage', () => {
     expect(screen.getAllByLabelText('Toggle theme')[0]).toBeInTheDocument();
   });
 
-  it('handles scroll to bottom check', () => {
+  it('does not react to window scroll at all', () => {
     render(<Navigation scrollToSection={vi.fn()} />);
 
-    // Mock window properties to simulate bottom of page
-    Object.defineProperty(window, 'scrollY', { value: 1000, writable: true });
+    // The page scrolls inside the ScrollControls element, so window scroll is
+    // never the signal here. Firing it must change nothing.
+    Object.defineProperty(window, 'scrollY', { value: 5000, writable: true });
     Object.defineProperty(window, 'innerHeight', { value: 500, writable: true });
     Object.defineProperty(document.documentElement, 'scrollHeight', { value: 1500, writable: true });
 
-    // Trigger scroll event
     fireEvent.scroll(window);
-    
-    // Check if Contact button has the active indicator
-    // The active indicator is a motion.div with layoutId="activeIndicator"
-    // We can check if the Contact button contains a child that represents this.
-    // Since we didn't mock framer-motion here yet, it might render as a normal div.
-    // Let's look for the button that contains the indicator.
-    
-    // We can also check if the button has the 'active' class if we mock styles.
-    // But let's try to find the indicator.
-    // Or we can just check if the 'Contact' button is the one that is active.
-    // Let's mock the styles to return 'active' for the active class.
-    const contactLink = screen.getByText('Contact').closest('button');
-    expect(contactLink).toHaveClass('active');
-  });
 
-  it('handles scroll not at bottom', () => {
-    render(<Navigation scrollToSection={vi.fn()} />);
-
-    // Mock window properties to simulate NOT bottom of page
-    Object.defineProperty(window, 'scrollY', { value: 50, writable: true });
-    Object.defineProperty(window, 'innerHeight', { value: 500, writable: true });
-    Object.defineProperty(document.documentElement, 'scrollHeight', { value: 1500, writable: true });
-
-    // Trigger scroll event
-    fireEvent.scroll(window);
-    
-    // Should NOT set active section to contact (unless it was already contact, but default is home)
-    // We can check that 'Contact' is NOT active.
-    const contactLink = screen.getByText('Contact').closest('button');
-    expect(contactLink).not.toHaveClass('active');
+    expect(screen.getByText('Contact').closest('button')).not.toHaveClass('active');
+    expect(screen.getByText('Home').closest('button')).toHaveClass('active');
   });
 
   it('handles IntersectionObserver updates', async () => {

--- a/src/components/Navigation.test.tsx
+++ b/src/components/Navigation.test.tsx
@@ -303,8 +303,11 @@ describe('Navigation', () => {
     vi.useRealTimers();
   });
 
-  it('detects bottom of page via scroll listener', () => {
-    // Add sections to DOM so initObserver proceeds
+  it('marks Contact active when the contact section dominates the viewport', () => {
+    // Replaces a test that drove window.scrollY. The page scrolls inside the
+    // ScrollControls element, so window scroll never fires here and that path
+    // was unreachable; IntersectionObserver is the real signal, including at
+    // the very bottom where Contact fills the observer band.
     const sections = ['home', 'about', 'skills', 'projects', 'contact'].map(id => {
       const el = document.createElement('section');
       el.id = id;
@@ -318,16 +321,41 @@ describe('Navigation', () => {
       </ThemeContext.Provider>
     );
 
-    // Simulate bottom of page
-    vi.spyOn(window, 'scrollY', 'get').mockReturnValue(1000);
-    vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(1000);
-    vi.spyOn(document.documentElement, 'scrollHeight', 'get').mockReturnValue(2000);
+    act(() => {
+      intersectionCallback?.(
+        [
+          { target: { id: 'projects' }, isIntersecting: true, intersectionRatio: 0.2 },
+          { target: { id: 'contact' }, isIntersecting: true, intersectionRatio: 0.8 },
+        ] as any,
+        {} as any
+      );
+    });
 
-    fireEvent.scroll(window);
+    expect(screen.getByText('Contact').closest('button')).toHaveClass(/active/);
 
-    const contactButton = screen.getByText('Contact').closest('button');
-    expect(contactButton).toHaveClass(/active/);
-    
     sections.forEach(el => document.body.removeChild(el));
+  });
+
+  it('ignores an observer batch where nothing is intersecting', () => {
+    const section = document.createElement('section');
+    section.id = 'home';
+    document.body.appendChild(section);
+
+    render(
+      <ThemeContext.Provider value={{ theme: 'dark', toggleTheme: mockToggleTheme }}>
+        <Navigation scrollToSection={mockScrollToSection} />
+      </ThemeContext.Provider>
+    );
+
+    act(() => {
+      intersectionCallback?.(
+        [{ target: { id: 'contact' }, isIntersecting: false, intersectionRatio: 0 }] as any,
+        {} as any
+      );
+    });
+
+    expect(screen.getByText('Home').closest('button')).toHaveClass(/active/);
+
+    document.body.removeChild(section);
   });
 });

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -19,7 +19,6 @@ interface NavigationProps {
 
 export function Navigation({ scrollToSection }: NavigationProps) {
   const [activeSection, setActiveSection] = useState('home');
-  const [isScrolled, setIsScrolled] = useState(false);
   const [isSoundEnabled, setIsSoundEnabled] = useState(() => soundFx.getSoundEnabled());
 
   const themeContext = useContext(ThemeContext);
@@ -32,17 +31,12 @@ export function Navigation({ scrollToSection }: NavigationProps) {
   };
 
   useEffect(() => {
-    const handleScroll = () => setIsScrolled(window.scrollY > 50);
-    window.addEventListener('scroll', handleScroll);
-    handleScroll();
-
-    return () => window.removeEventListener('scroll', handleScroll);
-  }, []);
-
-  useEffect(() => {
+    // The page scrolls inside the ScrollControls element, so window.scrollY and
+    // documentElement.scrollHeight are always 0 here. IntersectionObserver is
+    // the only reliable signal, and it does account for the container's
+    // transform -- including at the very bottom, where Contact fills the band.
     let observer: IntersectionObserver | null = null;
     let retryId: number | null = null;
-    let scrollHandler: (() => void) | null = null;
 
     const initObserver = () => {
       const sections = menuItems
@@ -61,15 +55,6 @@ export function Navigation({ scrollToSection }: NavigationProps) {
 
       observer = new IntersectionObserver(
         entries => {
-          // Check if we are at the bottom of the page
-          // Added scrollY check to prevent triggering at the top if page height is small initially
-          const isAtBottom = window.scrollY > 100 && (window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 100);
-          
-          if (isAtBottom) {
-            setActiveSection('contact');
-            return;
-          }
-
           const visibleEntry = entries
             .filter(entry => entry.isIntersecting)
             .sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
@@ -86,24 +71,11 @@ export function Navigation({ scrollToSection }: NavigationProps) {
       );
 
       sections.forEach(section => observer?.observe(section));
-      
-      // Also add a scroll listener to check for bottom
-      const handleScrollCheck = () => {
-        const isAtBottom = window.scrollY > 100 && (window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 100);
-        if (isAtBottom) {
-          setActiveSection('contact');
-        }
-      };
-      window.addEventListener('scroll', handleScrollCheck);
-      scrollHandler = handleScrollCheck;
     };
 
     initObserver();
 
     return () => {
-      if (scrollHandler) {
-        window.removeEventListener('scroll', scrollHandler);
-      }
       if (observer) {
         observer.disconnect();
       }
@@ -123,7 +95,7 @@ export function Navigation({ scrollToSection }: NavigationProps) {
   };
 
   return (
-    <header className={`${styles.header} ${isScrolled ? styles.scrolled : ''}`}>
+    <header className={styles.header}>
       <nav className={styles.nav}>
         <div 
           className={styles.logo}


### PR DESCRIPTION
Stacked PR **5 of 7**. Base: `feat/atmospheric-drift`.

`Navigation` carried the same defect already fixed in `App` and `Projects`: the page scrolls inside the `ScrollControls` element, so `window.scrollY` and `documentElement.scrollHeight` are always 0 and every `isAtBottom` branch was unreachable. `IntersectionObserver` already handles the bottom of the page correctly — confirmed in the browser, where Contact activates on arrival.

`isScrolled` was dead twice over: it never fired, **and** `styles.scrolled` does not exist in the CSS module. Removed.

Two tests asserted the unreachable behaviour by driving `window.scrollY`, which cannot happen in this app. Replaced with the real contract: Contact activates when it dominates the observer band, and firing window scroll changes nothing.

### Verification
All four local gates green. Browser: light theme and `prefers-reduced-motion` both render correctly with no console errors.

> Note: this PR also trimmed the inter-section spacer, but that change had no effect — `min-height: 100vh` from `.main > *` outranked it. That is corrected in PR 7 of the stack.
